### PR TITLE
Install Joist CLI in terragon-setup.sh with architecture note

### DIFF
--- a/terragon-setup.sh
+++ b/terragon-setup.sh
@@ -4,4 +4,20 @@
 
 pnpm install
 
+# Install Joist CLI
+echo "Installing Joist CLI..."
+# Note: Joist is currently only built for M-series Macs (darwin-arm64)
+# This installation may not work in a Linux container environment
+# You may need to request a Linux build from Joist or run it on your local Mac
+curl -sfSL https://joist.fsn1.your-objectstorage.com/cli/jcli-latest-darwin-arm64 -o "/tmp/jcli" && \
+    chmod +x "/tmp/jcli" && mv "/tmp/jcli" "/usr/local/bin/"
+
+# Verify installation
+if command -v jcli &> /dev/null; then
+    echo "Joist CLI installed successfully. Version: $(jcli version)"
+else
+    echo "Warning: Joist CLI installation may have failed (possibly due to architecture mismatch)"
+    echo "Joist is currently only available for M-series Macs (darwin-arm64)"
+fi
+
 echo "Setup complete!"


### PR DESCRIPTION
## Summary
- Adds installation of Joist CLI in the terragon-setup.sh setup script
- Includes a note about Joist CLI being built only for M-series Macs (darwin-arm64)
- Provides a warning if installation fails, likely due to architecture mismatch

## Changes

### Setup Script Updates
- Modified `terragon-setup.sh` to:
  - Download the latest Joist CLI binary for darwin-arm64
  - Make the binary executable and move it to `/usr/local/bin/`
  - Verify installation by checking if `jcli` command is available
  - Print the installed Joist CLI version on success
  - Print a warning message if installation fails, explaining the architecture limitation

## Notes
- Joist CLI installation may not work in Linux container environments due to architecture differences
- Users may need to request a Linux build or run Joist CLI on a local Mac with M-series chip

## Test plan
- Run `terragon-setup.sh` on an M-series Mac to confirm successful Joist CLI installation
- Run the script in a Linux container to verify the warning message appears
- Confirm that the setup script completes without errors

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6849db5c-2093-45de-b347-cde624250e3f