### PR TITLE
[CLI]: Migrate YAML configuration to JSON for patchy CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This is a CLI tool for managing Git patch workflows. It helps maintain curated p
 - `@stricli/core` - CLI framework
 - `es-toolkit` - Utility functions (lodash alternative)
 - `enquirer` - Interactive prompts
-- `yaml` - YAML parsing
+- `jsonc-parser` - JSON with comments parsing
 - `zod` - Runtime validation
 
 ## Testing Preferences

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ my-patch-repo/
 ├── patches/
 │   ├── path/in/repo/newFile.ts          # new file
 │   ├── path/in/repo/oldFile.ts.diff     # diff file
-├── patchy.yaml                          # optional config
+├── patchy.json                          # optional config
 
 repo-dir/
 ├── path/in/repo/newFile.ts              # will be copied from patches/
@@ -45,11 +45,11 @@ These flags are accepted by **all commands**:
 | `--repo-dir`      | Path to the Git repo you're patching             |
 | `--repo-base-dir` | Parent directory where upstream repos are cloned |
 | `--patches-dir`   | Path to your patch files (default: `./patches/`)   |
-| `--config`        | YAML config file (default: `patchy.yaml`)        |
+| `--config`        | JSON config file (default: `patchy.json`)        |
 | `--verbose`       | Enable verbose log output                        |
 | `--dry-run`       | Simulate the command without writing files       |
 
-> CLI flags override all values in `patchy.yaml`.
+> CLI flags override all values in `patchy.json`.
 
 ## Commands
 
@@ -93,22 +93,24 @@ Clone a repository into a subdirectory of `repo_base_dir`. The target directory 
 patchy repo clone [--repo-base-dir] [--ref] [--repo-url] 
 ```
 
-## Configuration (`patchy.yaml`)
+## Configuration (`patchy.json`)
 
 Optional file to set default values:
 
-```yaml
-repo_url: https://github.com/richardgill/upstream.git
-repo_dir: upstream-repo
-repo_base_dir: ../clones
-patches_dir: patches/
-ref: main
+```json
+{
+  "repo_url": "https://github.com/richardgill/upstream.git",
+  "repo_dir": "upstream-repo",
+  "repo_base_dir": "../clones",
+  "patches_dir": "patches/",
+  "ref": "main"
+}
 ```
 
 ### Precedence Order
 
 1. CLI flags
-2. `--config` (defaults to `./patchy.yaml`)
+2. `--config` (defaults to `./patchy.json`)
 
 ## Example Workflow
 

--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,8 @@
       "!**/dist",
       "!**/node_modules",
       "!**/tsconfig.json",
-      "!**/coverage"
+      "!**/coverage",
+      "!**/e2e/tmp"
     ]
   },
   "formatter": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@biomejs/biome": "2.1.1",
     "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.29.5",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.0.13",
     "@types/shell-quote": "^1.7.5",
     "@typescript/native-preview": "7.0.0-dev.20250712.1",
@@ -50,8 +49,8 @@
     "dedent": "^1.6.0",
     "enquirer": "^2.4.1",
     "es-toolkit": "^1.39.8",
+    "jsonc-parser": "^3.3.1",
     "ts-essentials": "^10.1.1",
-    "yaml": "^2.8.0",
     "zod": "^4.0.13"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,12 +23,12 @@ importers:
       es-toolkit:
         specifier: ^1.39.8
         version: 1.39.8
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       ts-essentials:
         specifier: ^10.1.1
         version: 10.1.1
-      yaml:
-        specifier: ^2.8.0
-        version: 2.8.0
       zod:
         specifier: ^4.0.13
         version: 4.0.13
@@ -42,9 +42,6 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.5
         version: 2.29.5
-      '@types/js-yaml':
-        specifier: ^4.0.9
-        version: 4.0.9
       '@types/node':
         specifier: ^24.0.13
         version: 24.0.13
@@ -675,9 +672,6 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
-
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -1125,6 +1119,9 @@ packages:
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -1644,11 +1641,6 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yaml@2.8.0:
-    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -2156,8 +2148,6 @@ snapshots:
 
   '@types/estree@1.0.6': {}
 
-  '@types/js-yaml@4.0.9': {}
-
   '@types/node@12.20.55': {}
 
   '@types/node@24.0.13':
@@ -2639,6 +2629,8 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
+  jsonc-parser@3.3.1: {}
+
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
@@ -3085,8 +3077,6 @@ snapshots:
       strip-ansi: 7.1.0
 
   y18n@5.0.8: {}
-
-  yaml@2.8.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/src/commands/init/impl.ts
+++ b/src/commands/init/impl.ts
@@ -3,7 +3,6 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import enquirer from "enquirer";
 import { compact, omitBy } from "es-toolkit";
-import { stringify } from "yaml";
 import {
   DEFAULT_CONFIG_PATH,
   DEFAULT_PATCHES_DIR,
@@ -124,10 +123,10 @@ export default async function (
     return;
   }
 
-  const yamlContent = generateYamlConfig(finalConfig);
+  const jsonContent = generateJsonConfig(finalConfig);
 
   try {
-    await writeFile(configPath, yamlContent, "utf8");
+    await writeFile(configPath, jsonContent, "utf8");
     this.process.stdout.write(`Created configuration file: ${configPath}\n`);
   } catch (error) {
     this.process.stderr.write(
@@ -146,14 +145,14 @@ export default async function (
   this.process.stdout.write(`3. Generate patches: patchy generate\n`);
 }
 
-const generateYamlConfig = (config: RequiredConfigData): string => {
+const generateJsonConfig = (config: RequiredConfigData): string => {
   const validatedConfig = requiredConfigSchema.parse(config);
 
-  const yamlData = omitBy(
+  const jsonData = omitBy(
     validatedConfig,
     (value, key) =>
       value === "" || value == null || (key === "verbose" && value === false),
   );
 
-  return stringify(yamlData);
+  return `${JSON.stringify(jsonData, null, 2)}\n`;
 };

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,3 +1,3 @@
 export const DEFAULT_PATCHES_DIR = "./patches/";
-export const DEFAULT_CONFIG_PATH = "./patchy.yaml";
+export const DEFAULT_CONFIG_PATH = "./patchy.json";
 export const DEFAULT_REF = "main";

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -13,7 +13,7 @@ export const requiredConfigSchema = z.object(baseConfigFields).strict();
 
 export type RequiredConfigData = z.infer<typeof requiredConfigSchema>;
 
-export const yamlConfigSchema = z
+export const jsonConfigSchema = z
   .object({
     repo_url: baseConfigFields.repo_url.optional(),
     ref: baseConfigFields.ref.optional(),
@@ -24,4 +24,4 @@ export const yamlConfigSchema = z
     dry_run: z.boolean().optional(),
   })
   .strict();
-export type YamlConfig = z.infer<typeof yamlConfigSchema>;
+export type JsonConfig = z.infer<typeof jsonConfigSchema>;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -17,8 +17,8 @@ export type ApplyCommandFlags = SharedFlags;
 
 export type GenerateCommandFlags = SharedFlags;
 
-// Note: underscore_case property names match YAML config keys
-export type CompleteYamlConfig = {
+// Note: underscore_case property names match JSON config keys
+export type CompleteJsonConfig = {
   repo_url: string;
   ref: string;
   repo_base_dir: string;
@@ -28,9 +28,9 @@ export type CompleteYamlConfig = {
   dry_run: boolean;
 };
 
-export type YamlKey = keyof CompleteYamlConfig;
+export type JsonKey = keyof CompleteJsonConfig;
 
-export type ResolvedConfig = CompleteYamlConfig & {
+export type ResolvedConfig = CompleteJsonConfig & {
   absoluteRepoBaseDir: string;
   absoluteRepoDir: string;
   absolutePatchesDir: string;
@@ -86,7 +86,7 @@ export const CONFIG_FIELD_METADATA = {
     example: "true",
   },
 } as const satisfies Record<
-  YamlKey,
+  JsonKey,
   {
     flag: keyof SharedFlags;
     name: string;

--- a/src/e2e/apply.test.ts
+++ b/src/e2e/apply.test.ts
@@ -21,14 +21,14 @@ describe("patchy apply", () => {
         repoBaseDir: "repos",
         repoDir: "main",
       },
-      yamlConfig: {
+      jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
         repo_dir: "config-repo",
       },
     });
 
     const result = await assertSuccessfulCommand(
-      `apply --repo-dir main --repo-base-dir repos --patches-dir patches --config patchy.yaml --verbose --dry-run`,
+      `apply --repo-dir main --repo-base-dir repos --patches-dir patches --config patchy.json --verbose --dry-run`,
       tmpDir,
     );
 
@@ -53,7 +53,7 @@ describe("patchy apply", () => {
         repoBaseDir: "repos",
         repoDir: "upstream",
       },
-      yamlConfig: {
+      jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
         repo_dir: "upstream",
         repo_base_dir: `${tmpDir}/repos`,
@@ -63,7 +63,7 @@ describe("patchy apply", () => {
     });
 
     const result = await assertSuccessfulCommand(
-      `apply --config patchy.yaml --dry-run --verbose`,
+      `apply --config patchy.json --dry-run --verbose`,
       tmpDir,
     );
 
@@ -88,7 +88,7 @@ describe("patchy apply", () => {
         repoBaseDir: "repos",
         repoDir: "cli-repo",
       },
-      yamlConfig: {
+      jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
         repo_dir: "config-repo",
         repo_base_dir: `${tmpDir}/repos`,
@@ -98,7 +98,7 @@ describe("patchy apply", () => {
     });
 
     const result = await assertSuccessfulCommand(
-      `apply --repo-dir cli-repo --patches-dir cli-patches --config patchy.yaml --dry-run --verbose`,
+      `apply --repo-dir cli-repo --patches-dir cli-patches --config patchy.json --dry-run --verbose`,
       tmpDir,
     );
 
@@ -124,7 +124,7 @@ describe("patchy apply", () => {
   //         repoBaseDir: "repos",
   //         repoDir: "main",
   //       },
-  //       yamlConfig: {
+  //       jsonConfig: {
   //         repo_dir: "main",
   //         repo_base_dir: join(tmpDir, "repos"),
   //         patches_dir: "patches",
@@ -145,7 +145,7 @@ describe("patchy apply", () => {
   //         patchesDir: "patches",
   //         repoBaseDir: "repos",
   //       },
-  //       yamlConfig: {
+  //       jsonConfig: {
   //         repo_url: "https://github.com/example/test-repo.git",
   //         repo_base_dir: join(tmpDir, "repos"),
   //         patches_dir: "patches",
@@ -166,7 +166,7 @@ describe("patchy apply", () => {
   //         patchesDir: "patches",
   //         repoBaseDir: "repos",
   //       },
-  //       yamlConfig: {
+  //       jsonConfig: {
   //         repo_base_dir: join(tmpDir, "repos"),
   //         patches_dir: "patches",
   //       },
@@ -185,7 +185,7 @@ describe("patchy apply", () => {
   //       directories: {
   //         patchesDir: "patches",
   //       },
-  //       yamlConfig: {},
+  //       jsonConfig: {},
   //     });
   //
   //     await assertFailedCommand(
@@ -202,7 +202,7 @@ describe("patchy apply", () => {
   //       directories: {
   //         patchesDir: "patches",
   //       },
-  //       yamlConfig: {},
+  //       jsonConfig: {},
   //     });
   //
   //     // Remove any existing patchy.yaml file
@@ -228,7 +228,7 @@ describe("patchy apply", () => {
   //         repoBaseDir: "repos",
   //         repoDir: "main",
   //       },
-  //       yamlConfig: {
+  //       jsonConfig: {
   //         repo_url: "https://github.com/example/test-repo.git",
   //         repo_dir: "main",
   //         repo_base_dir: join(tmpDir, "repos"),
@@ -261,7 +261,7 @@ describe("patchy apply", () => {
   //         repoBaseDir: "repos",
   //         repoDir: "main",
   //       },
-  //       yamlConfig: {
+  //       jsonConfig: {
   //         repo_url: "https://github.com/example/test-repo.git",
   //         repo_dir: "main",
   //         repo_base_dir: join(tmpDir, "repos"),
@@ -295,7 +295,7 @@ describe("patchy apply", () => {
   //       directories: {
   //         patchesDir: "patches",
   //       },
-  //       yamlConfig: {
+  //       jsonConfig: {
   //         repo_url: "https://github.com/yaml/repo.git",
   //         repo_dir: "yaml-dir",
   //         repo_base_dir: "/yaml/base",
@@ -334,7 +334,7 @@ describe("patchy apply", () => {
   //       directories: {
   //         patchesDir: "patches",
   //       },
-  //       yamlConfig: {
+  //       jsonConfig: {
   //         repo_url: "https://github.com/yaml/repo.git",
   //         repo_dir: "yaml-dir",
   //         repo_base_dir: "/yaml/base",
@@ -373,7 +373,7 @@ describe("patchy apply", () => {
   //       directories: {
   //         patchesDir: "patches",
   //       },
-  //       yamlConfig: {
+  //       jsonConfig: {
   //         repo_url: "https://github.com/test/repo.git",
   //         repo_dir: "test-dir",
   //       },
@@ -407,7 +407,7 @@ describe("patchy apply", () => {
   //       directories: {
   //         patchesDir: "patches",
   //       },
-  //       yamlConfig: {
+  //       jsonConfig: {
   //         repo_url: "https://github.com/yaml/repo.git",
   //         repo_dir: "yaml-dir",
   //         repo_base_dir: "/yaml/base",
@@ -449,7 +449,7 @@ describe("patchy apply", () => {
   //         repoBaseDir: "repos",
   //         repoDir: "test-dir",
   //       },
-  //       yamlConfig: {
+  //       jsonConfig: {
   //         repo_url: "https://github.com/test/repo.git",
   //         repo_dir: "test-dir",
   //         repo_base_dir: join(tmpDir, "repos"),
@@ -481,7 +481,7 @@ describe("patchy apply", () => {
   //         repoBaseDir: "repos",
   //         repoDir: "test-dir",
   //       },
-  //       yamlConfig: {
+  //       jsonConfig: {
   //         repo_url: "https://github.com/test/repo.git",
   //         repo_dir: "test-dir",
   //         repo_base_dir: join(tmpDir, "repos"),

--- a/src/e2e/init.test.ts
+++ b/src/e2e/init.test.ts
@@ -21,11 +21,11 @@ describe("patchy init", () => {
   const assertSuccessfulInit = async (command: string) => {
     await assertSuccessfulCommand(command, tmpDir);
 
-    const configPath = join(tmpDir, "patchy.yaml");
+    const configPath = join(tmpDir, "patchy.json");
     assertConfigFileExists(configPath);
 
-    const yamlContent = readFileSync(configPath, "utf-8");
-    return yamlContent.trim();
+    const jsonContent = readFileSync(configPath, "utf-8");
+    return jsonContent.trim();
   };
 
   const assertFailedInit = async ({
@@ -43,16 +43,18 @@ describe("patchy init", () => {
       tmpDir,
       createDirectories: { repoBaseDir: "repoBaseDir1", repoDir: "main" },
     });
-    const yamlContent = await assertSuccessfulInit(
-      `init --repo-url https://github.com/example/test-repo.git --repo-dir main --repo-base-dir repoBaseDir1 --patches-dir patches --ref main --config patchy.yaml --force`,
+    const jsonContent = await assertSuccessfulInit(
+      `init --repo-url https://github.com/example/test-repo.git --repo-dir main --repo-base-dir repoBaseDir1 --patches-dir patches --ref main --config patchy.json --force`,
     );
 
-    expect(stabilizeTempDir(yamlContent)).toMatchInlineSnapshot(`
-      "repo_url: https://github.com/example/test-repo.git
-      ref: main
-      repo_base_dir: repoBaseDir1
-      repo_dir: main
-      patches_dir: patches"
+    expect(stabilizeTempDir(jsonContent)).toMatchInlineSnapshot(`
+      "{
+        \"repo_url\": \"https://github.com/example/test-repo.git\",
+        \"ref\": \"main\",
+        \"repo_base_dir\": \"repoBaseDir1\",
+        \"repo_dir\": \"main\",
+        \"patches_dir\": \"patches\"
+      }"
     `);
   });
 
@@ -63,7 +65,7 @@ describe("patchy init", () => {
         createDirectories: { repoBaseDir: "repoBaseDir1", repoDir: "main" },
       });
       await assertFailedInit({
-        command: `init --repo-url github.com/example/repo --repo-dir main --repo-base-dir repoBaseDir1 --patches-dir patches --ref main --config patchy.yaml --force`,
+        command: `init --repo-url github.com/example/repo --repo-dir main --repo-base-dir repoBaseDir1 --patches-dir patches --ref main --config patchy.json --force`,
         expectedErrors: "valid Git URL",
       });
     });
@@ -75,7 +77,7 @@ describe("patchy init", () => {
       });
 
       await assertFailedInit({
-        command: `init --repo-url https://invalid_domain/repo --repo-dir main --repo-base-dir repoBaseDir1 --patches-dir patches --ref main --config patchy.yaml --force`,
+        command: `init --repo-url https://invalid_domain/repo --repo-dir main --repo-base-dir repoBaseDir1 --patches-dir patches --ref main --config patchy.json --force`,
         expectedErrors: "valid Git URL",
       });
     });
@@ -87,7 +89,7 @@ describe("patchy init", () => {
       });
 
       await assertFailedInit({
-        command: `init --repo-url https://github.com/ --repo-dir main --repo-base-dir repoBaseDir1 --patches-dir patches --ref main --config patchy.yaml --force`,
+        command: `init --repo-url https://github.com/ --repo-dir main --repo-base-dir repoBaseDir1 --patches-dir patches --ref main --config patchy.json --force`,
         expectedErrors: "valid Git URL",
       });
     });
@@ -96,16 +98,16 @@ describe("patchy init", () => {
       setupTestWithConfig({
         tmpDir,
         createDirectories: { repoBaseDir: "repoBaseDir1", repoDir: "main" },
-        yamlConfig: { hello: "world" },
+        jsonConfig: { hello: "world" },
       });
 
       await runPatchy(
-        `init --repo-url https://github.com/example/repo.git --repo-dir main --repo-base-dir repoBaseDir1 --patches-dir patches --ref main --config patchy.yaml --force`,
+        `init --repo-url https://github.com/example/repo.git --repo-dir main --repo-base-dir repoBaseDir1 --patches-dir patches --ref main --config patchy.json --force`,
         tmpDir,
       );
 
       await assertFailedInit({
-        command: `init --repo-url https://github.com/example/another-repo.git --repo-dir main --repo-base-dir repoBaseDir1 --patches-dir patches --ref main --config patchy.yaml`,
+        command: `init --repo-url https://github.com/example/another-repo.git --repo-dir main --repo-base-dir repoBaseDir1 --patches-dir patches --ref main --config patchy.json`,
         expectedErrors: [
           "Configuration file already exists",
           "Use --force to overwrite",
@@ -119,7 +121,7 @@ describe("patchy init", () => {
         createDirectories: { repoBaseDir: "repoBaseDir1", repoDir: "main" },
       });
       await assertFailedInit({
-        command: `init --repo-url "" --repo-dir main --repo-base-dir repoBaseDir1 --patches-dir patches --ref main --config patchy.yaml --force`,
+        command: `init --repo-url "" --repo-dir main --repo-base-dir repoBaseDir1 --patches-dir patches --ref main --config patchy.json --force`,
         expectedErrors: "Repository URL is required",
       });
     });

--- a/src/e2e/test-utils.test.ts
+++ b/src/e2e/test-utils.test.ts
@@ -6,9 +6,9 @@ import { stabilizeTempDir, writeTestConfig } from "./test-utils";
 
 describe("test-utils", () => {
   describe("writeTestConfig", () => {
-    it("should generate YAML content correctly", async () => {
+    it("should generate JSON content correctly", async () => {
       const tempDir = mkdtempSync(join(tmpdir(), "test-utils-"));
-      const configPath = join(tempDir, "test-config.yaml");
+      const configPath = join(tempDir, "test-config.json");
 
       await writeTestConfig(configPath, {
         repo_url: "https://github.com/example/repo.git",
@@ -20,16 +20,18 @@ describe("test-utils", () => {
         dry_run: false,
       });
 
-      const yamlContent = readFileSync(configPath, "utf-8");
+      const jsonContent = readFileSync(configPath, "utf-8");
 
-      expect(yamlContent).toMatchInlineSnapshot(`
-        "repo_url: https://github.com/example/repo.git
-        repo_dir: main
-        repo_base_dir: /tmp/repos
-        patches_dir: patches
-        ref: main
-        verbose: true
-        dry_run: false"
+      expect(jsonContent).toMatchInlineSnapshot(`
+        "{
+          \"repo_url\": \"https://github.com/example/repo.git\",
+          \"repo_dir\": \"main\",
+          \"repo_base_dir\": \"/tmp/repos\",
+          \"patches_dir\": \"patches\",
+          \"ref\": \"main\",
+          \"verbose\": true,
+          \"dry_run\": false
+        }"
       `);
 
       rmSync(tempDir, { recursive: true });

--- a/src/e2e/test-utils.ts
+++ b/src/e2e/test-utils.ts
@@ -70,10 +70,8 @@ export const writeTestConfig = async (
   configPath: string,
   config: Record<string, string | boolean | number>,
 ) => {
-  const yamlContent = Object.entries(config)
-    .map(([key, value]) => `${key}: ${value}`)
-    .join("\n");
-  await writeFile(configPath, yamlContent);
+  const jsonContent = JSON.stringify(config, null, 2);
+  await writeFile(configPath, jsonContent);
 };
 
 export const assertConfigFileExists = (configPath: string) => {
@@ -140,7 +138,7 @@ const createTestDirStructure = async (
 export const setupTestWithConfig = async ({
   tmpDir,
   createDirectories = {},
-  yamlConfig = {},
+  jsonConfig = {},
 }: {
   tmpDir: string;
   createDirectories?: {
@@ -148,12 +146,12 @@ export const setupTestWithConfig = async ({
     repoBaseDir?: string | undefined;
     repoDir?: string | undefined;
   };
-  yamlConfig?: Record<string, string | boolean | number>;
+  jsonConfig?: Record<string, string | boolean | number>;
 }): Promise<TestContext> => {
   const ctx = await createTestDirStructure(tmpDir, createDirectories);
 
-  const configPath = resolve(tmpDir, "patchy.yaml");
-  await writeTestConfig(configPath, yamlConfig);
+  const configPath = resolve(tmpDir, "patchy.json");
+  await writeTestConfig(configPath, jsonConfig);
 
   return ctx;
 };


### PR DESCRIPTION
Migrate project from YAML to JSON configuration, updating configuration parsing, file references, and test utilities to use JSON with comments parsing. Removed YAML-related dependencies and added JSONC parser.