### PR TITLE
Refactor runPatchy CLI integration and improve e2e test utilities

### DIFF
--- a/src/e2e/apply.test.ts
+++ b/src/e2e/apply.test.ts
@@ -138,8 +138,7 @@ describe("patchy apply", () => {
         Missing Repository directory: set repo_dir in ./patchy.json or use --repo-dir flag
 
       You can set up ./patchy.json by running:
-        patchy init
-      "
+        patchy init"
     `);
   });
 
@@ -192,8 +191,7 @@ describe("patchy apply", () => {
       "Validation errors:
 
       repo_base_dir: non-existent-base in ./patchy.json does not exist: <TEST_DIR>/non-existent-base
-      patches_dir: non-existent-patches in ./patchy.json does not exist: <TEST_DIR>/non-existent-patches
-      "
+      patches_dir: non-existent-patches in ./patchy.json does not exist: <TEST_DIR>/non-existent-patches"
     `);
   });
 
@@ -433,8 +431,7 @@ describe("patchy apply", () => {
         Missing Repository directory: set repo_dir in ./patchy.json or use --repo-dir flag
 
       You can set up ./patchy.json by running:
-        patchy init
-      "
+        patchy init"
     `);
   });
 

--- a/src/e2e/init.test.ts
+++ b/src/e2e/init.test.ts
@@ -33,7 +33,7 @@ describe("patchy init", () => {
   };
 
   it("should initialize patchy with all flags", async () => {
-    setupTestWithConfig({
+    await setupTestWithConfig({
       tmpDir,
       createDirectories: { repoBaseDir: "repoBaseDir1", repoDir: "main" },
     });
@@ -54,7 +54,7 @@ describe("patchy init", () => {
 
   describe("error cases", () => {
     it("should fail with malformed repo url - missing protocol", async () => {
-      setupTestWithConfig({
+      await setupTestWithConfig({
         tmpDir,
         createDirectories: { repoBaseDir: "repoBaseDir1", repoDir: "main" },
       });
@@ -68,7 +68,7 @@ describe("patchy init", () => {
     });
 
     it("should fail with malformed repo url - invalid domain", async () => {
-      setupTestWithConfig({
+      await setupTestWithConfig({
         tmpDir,
         createDirectories: { repoBaseDir: "repoBaseDir1", repoDir: "main" },
       });
@@ -82,7 +82,7 @@ describe("patchy init", () => {
     });
 
     it("should fail with malformed repo url - incomplete path", async () => {
-      setupTestWithConfig({
+      await setupTestWithConfig({
         tmpDir,
         createDirectories: { repoBaseDir: "repoBaseDir1", repoDir: "main" },
       });
@@ -94,7 +94,7 @@ describe("patchy init", () => {
     });
 
     it("should fail when config file exists without force flag", async () => {
-      setupTestWithConfig({
+      await setupTestWithConfig({
         tmpDir,
         createDirectories: { repoBaseDir: "repoBaseDir1", repoDir: "main" },
         jsonConfig: { hello: "world" },
@@ -117,7 +117,7 @@ describe("patchy init", () => {
     });
 
     it("should fail with validation error for empty repo_url", async () => {
-      setupTestWithConfig({
+      await setupTestWithConfig({
         tmpDir,
         createDirectories: { repoBaseDir: "repoBaseDir1", repoDir: "main" },
       });


### PR DESCRIPTION
## Summary
- Refactor `runPatchy` function to use `fork` for CLI execution instead of `execa`.
- Improve capturing of stdout, stderr, and exit codes in e2e tests.
- Add async/await to test setup calls in `init.test.ts` for proper async handling.
- Minor formatting fixes in `apply.test.ts` for consistent error message strings.

## Changes

### e2e Test Utilities
- Replaced `execa` with Node.js `fork` to run CLI commands in a child process.
- Captured stdout and stderr streams manually to provide detailed command output.
- Ensured test directories are created before running commands.
- Updated `PatchyResult` type to include `stdout`, `stderr`, `exitCode`, and `cwd`.

### e2e Tests
- Added `await` to `setupTestWithConfig` calls in `init.test.ts` to handle asynchronous setup correctly.
- Fixed trailing whitespace in error message strings in `apply.test.ts` for consistency.

## Test plan
- Verified existing e2e tests pass with updated `runPatchy` implementation.
- Confirmed async test setups in `init.test.ts` run without timing issues.
- Checked error message formatting in `apply.test.ts` matches expected output.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6f31ea8c-d97a-4a42-9f67-def8ae350ff5