### PR TITLE
Refactor runPatchy to use Node.js spawn and update tests

### DIFF
--- a/src/e2e/apply.test.ts
+++ b/src/e2e/apply.test.ts
@@ -138,8 +138,7 @@ describe("patchy apply", () => {
         Missing Repository directory: set repo_dir in ./patchy.json or use --repo-dir flag
 
       You can set up ./patchy.json by running:
-        patchy init
-      "
+        patchy init"
     `);
   });
 
@@ -192,8 +191,7 @@ describe("patchy apply", () => {
       "Validation errors:
 
       repo_base_dir: non-existent-base in ./patchy.json does not exist: <TEST_DIR>/non-existent-base
-      patches_dir: non-existent-patches in ./patchy.json does not exist: <TEST_DIR>/non-existent-patches
-      "
+      patches_dir: non-existent-patches in ./patchy.json does not exist: <TEST_DIR>/non-existent-patches"
     `);
   });
 
@@ -433,8 +431,7 @@ describe("patchy apply", () => {
         Missing Repository directory: set repo_dir in ./patchy.json or use --repo-dir flag
 
       You can set up ./patchy.json by running:
-        patchy init
-      "
+        patchy init"
     `);
   });
 


### PR DESCRIPTION
## Summary
- Refactor `runPatchy` utility to run the built CLI using Node.js `spawn` instead of `execa` with `tsx`.
- Update test utilities to handle process output and errors with the new spawn-based implementation.
- Minor cleanup in `apply.test.ts` to fix trailing spaces in test error messages.

## Changes

### Test Utilities
- Replaced `execa` invocation with `child_process.spawn` to run `dist/cli.js` directly.
- Implemented manual capturing of `stdout`, `stderr`, and exit code.
- Created a promise-based interface that resolves with a result object mimicking `execa`'s `Result` type.
- Added error handling for spawn errors to capture error messages in `stderr`.

### Tests
- Fixed trailing spaces in error message strings in `apply.test.ts` for consistency.

## Test plan
- [x] Run existing end-to-end tests to verify CLI execution via spawn works correctly.
- [x] Confirm error messages and outputs are captured and returned as expected.
- [x] Validate no regressions in patch application tests after refactor.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/30d762c8-4ab1-4561-aaa2-09fd4e0f719b