### PR TITLE
Replace custom SnakeToCamel with ts-essentials CamelCase

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,5 +1,4 @@
-import type { MarkOptional } from "ts-essentials";
-import type { SnakeToCamel } from "~/types/utils";
+import type { CamelCase, MarkOptional } from "ts-essentials";
 
 // CONFIG_FIELD_METADATA is the single source of truth for config field definitions
 export const CONFIG_FIELD_METADATA = {
@@ -180,7 +179,7 @@ export type MergedConfig = MarkOptional<
 >;
 
 export type CamelCaseResolvedConfig = {
-  [K in JsonKey as SnakeToCamel<K>]: CompleteJsonConfig[K];
+  [K in JsonKey as CamelCase<K>]: CompleteJsonConfig[K];
 };
 
 export type PartialResolvedConfig = Partial<ResolvedConfig>;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,8 +1,3 @@
-/** Converts snake_case string literal type to camelCase */
-export type SnakeToCamel<S extends string> = S extends `${infer H}_${infer T}`
-  ? `${H}${Capitalize<SnakeToCamel<T>>}`
-  : S;
-
 /** Infer the parsed value type from a stricli flag definition */
 type InferFlagValue<F> = F extends { kind: "boolean" }
   ? boolean


### PR DESCRIPTION
## Summary

- Replace custom `SnakeToCamel` type with `CamelCase` from ts-essentials
- Remove now-unused `SnakeToCamel` from `src/types/utils.ts`

## Analysis

Reviewed all custom types in the codebase against ts-essentials:

| Type | Can use ts-essentials? |
|------|------------------------|
| `SnakeToCamel` | ✅ Replaced with `CamelCase` |
| `InferFlagValue` | ❌ Domain-specific (stricli) |
| `ParsedFlags` | ❌ Domain-specific (stricli) |
| `ParseResult` | ❌ No Result type in ts-essentials |
| `TypeMap` | ❌ Literal-to-type map |
| `FlagName`, `FlagType`, etc. | ❌ Domain-specific extractions |
| `MergedConfig` | ✅ Already uses `MarkOptional` |

The ts-essentials `CamelCase` is more robust as it handles multiple formats (snake_case, kebab-case, CONSTANT_CASE) while our custom implementation only handled snake_case.

## Test plan

- [x] `bun run test` passes (140 tests)
- [x] Type checking passes