### PR TITLE
[Patchy]: Rename `repoBaseDir` to `clonesDir` for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ my-patch-repo/
   "patches_dir": "./patches/", // Override: --patches-dir | env: PATCHY_PATCHES_DIR
 
   // Parent directory for cloning repos. You can easily clone more repos here from repo_url.
-  "repo_base_dir": "~/repos", // Override: --repo-base-dir | env: PATCHY_REPO_BASE_DIR
+  "clones_dir": "./clones/", // Override: --clones-dir | env: PATCHY_CLONES_DIR
 
   // Git ref to checkout (branch, tag, SHA).
   "ref": "main" // Override: --ref | env: PATCHY_REF
@@ -129,10 +129,10 @@ patchy repo checkout --ref main [--repo-dir]
 
 ### `patchy repo clone --url <git-url>`
 
-Clone a repository into a subdirectory of `repo_base_dir`. The target directory is derived from the repo name.
+Clone a repository into a subdirectory of `clones_dir`. The target directory is derived from the repo name.
 
 ```sh
-patchy repo clone [--repo-base-dir] [--ref] [--repo-url] 
+patchy repo clone [--clones-dir] [--ref] [--repo-url] 
 ```
 
 ## License

--- a/scripts/generate-schema.test.ts
+++ b/scripts/generate-schema.test.ts
@@ -12,13 +12,13 @@ describe("generateJsonSchema", () => {
           "$schema": {
             "type": "string",
           },
+          "clones_dir": {
+            "type": "string",
+          },
           "patches_dir": {
             "type": "string",
           },
           "ref": {
-            "type": "string",
-          },
-          "repo_base_dir": {
             "type": "string",
           },
           "repo_dir": {

--- a/src/cli-fields/enriched-fields.ts
+++ b/src/cli-fields/enriched-fields.ts
@@ -1,7 +1,7 @@
 // Base type for computed absolute paths
 // This file has no imports from this module to avoid circular dependencies
 export type EnrichedFields = {
-  absoluteRepoBaseDir: string | undefined;
+  absoluteClonesDir: string | undefined;
   absoluteRepoDir: string | undefined;
   absolutePatchesDir: string | undefined;
 };

--- a/src/cli-fields/metadata.ts
+++ b/src/cli-fields/metadata.ts
@@ -74,21 +74,21 @@ export const FLAG_METADATA = {
       },
     },
   },
-  repo_base_dir: {
+  clones_dir: {
     configField: true,
     requiredInConfig: false,
-    env: "PATCHY_REPO_BASE_DIR",
+    env: "PATCHY_CLONES_DIR",
     type: "string",
-    name: "Repository base directory",
-    example: "./upstream",
-    defaultValue: "./upstream/",
-    validate: (config, _key) => directoryExists(config, "absoluteRepoBaseDir"),
+    name: "Clones directory",
+    example: "./clones",
+    defaultValue: "./clones/",
+    validate: (config, _key) => directoryExists(config, "absoluteClonesDir"),
     stricliFlag: {
-      "repo-base-dir": {
+      "clones-dir": {
         kind: "parsed",
         parse: String,
         brief:
-          "Parent directory where upstream repos are cloned [env: PATCHY_REPO_BASE_DIR]",
+          "Directory where upstream repos are cloned [env: PATCHY_CLONES_DIR]",
         optional: true,
       },
     },

--- a/src/cli-fields/resolver.test.ts
+++ b/src/cli-fields/resolver.test.ts
@@ -43,13 +43,13 @@ describe("createEnrichedMergedConfig", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repoBaseDir1",
+        clonesDir: "clonesDir1",
         repoDir: "repoDir1",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
-        repo_base_dir: "repoBaseDir1",
+        clones_dir: "clonesDir1",
         repo_dir: "repoDir1",
         ref: "main",
         verbose: true,
@@ -63,7 +63,7 @@ describe("createEnrichedMergedConfig", () => {
 
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
     ];
 
@@ -79,14 +79,14 @@ describe("createEnrichedMergedConfig", () => {
       "{
         "repo_url": "https://github.com/example/flag-repo.git",
         "repo_dir": "repoDir1",
-        "repo_base_dir": "repoBaseDir1",
+        "clones_dir": "clonesDir1",
         "patches_dir": "./patches/",
         "ref": "main",
         "verbose": true,
         "dry_run": true,
         "config": "./patchy.json",
-        "absoluteRepoBaseDir": "<TEST_DIR>/repoBaseDir1",
-        "absoluteRepoDir": "<TEST_DIR>/repoBaseDir1/repoDir1",
+        "absoluteClonesDir": "<TEST_DIR>/clonesDir1",
+        "absoluteRepoDir": "<TEST_DIR>/clonesDir1/repoDir1",
         "absolutePatchesDir": "<TEST_DIR>/patches"
       }"
     `,
@@ -134,12 +134,12 @@ describe("createEnrichedMergedConfig", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repoBaseDir1",
+        clonesDir: "clonesDir1",
         repoDir: "repoDir1",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/repo.git",
-        repo_base_dir: "repoBaseDir1",
+        clones_dir: "clonesDir1",
         repo_dir: "repoDir1",
       },
     });
@@ -147,7 +147,7 @@ describe("createEnrichedMergedConfig", () => {
     const flags: SharedFlags = {};
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
     ];
 
@@ -163,14 +163,14 @@ describe("createEnrichedMergedConfig", () => {
       "{
         "repo_url": "https://github.com/example/repo.git",
         "repo_dir": "repoDir1",
-        "repo_base_dir": "repoBaseDir1",
+        "clones_dir": "clonesDir1",
         "patches_dir": "./patches/",
         "ref": "main",
         "verbose": false,
         "dry_run": false,
         "config": "./patchy.json",
-        "absoluteRepoBaseDir": "<TEST_DIR>/repoBaseDir1",
-        "absoluteRepoDir": "<TEST_DIR>/repoBaseDir1/repoDir1",
+        "absoluteClonesDir": "<TEST_DIR>/clonesDir1",
+        "absoluteRepoDir": "<TEST_DIR>/clonesDir1/repoDir1",
         "absolutePatchesDir": "<TEST_DIR>/patches"
       }"
     `,
@@ -228,7 +228,7 @@ describe("createEnrichedMergedConfig", () => {
       createDirectories: {},
       jsonConfig: {
         repo_url: "https://github.com/example/repo.git",
-        repo_base_dir: "non-existent-base",
+        clones_dir: "non-existent-base",
         repo_dir: "non-existent-repo",
         patches_dir: "non-existent-patches",
       },
@@ -237,7 +237,7 @@ describe("createEnrichedMergedConfig", () => {
     const flags: SharedFlags = {};
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
       "patches_dir",
     ];
@@ -252,7 +252,7 @@ describe("createEnrichedMergedConfig", () => {
     expect(stabilizeTempDir(result.error)).toMatchInlineSnapshot(`
       "Validation errors:
 
-      repo_base_dir: non-existent-base in ./patchy.json does not exist: <TEST_DIR>/non-existent-base
+      clones_dir: non-existent-base in ./patchy.json does not exist: <TEST_DIR>/non-existent-base
       patches_dir: non-existent-patches in ./patchy.json does not exist: <TEST_DIR>/non-existent-patches
 
       "
@@ -263,13 +263,13 @@ describe("createEnrichedMergedConfig", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "flag-base",
+        clonesDir: "flag-base",
         repoDir: "flag-repo",
         patchesDir: "flag-patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
-        repo_base_dir: "json-base",
+        clones_dir: "json-base",
         repo_dir: "json-repo",
         patches_dir: "json-patches",
         ref: "json-ref",
@@ -279,7 +279,7 @@ describe("createEnrichedMergedConfig", () => {
 
     const flags: SharedFlags = {
       "repo-url": "https://github.com/example/flag-repo.git",
-      "repo-base-dir": "flag-base",
+      "clones-dir": "flag-base",
       "repo-dir": "flag-repo",
       "patches-dir": "flag-patches",
       ref: "flag-ref",
@@ -287,7 +287,7 @@ describe("createEnrichedMergedConfig", () => {
     };
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
       "patches_dir",
     ];
@@ -304,13 +304,13 @@ describe("createEnrichedMergedConfig", () => {
       "{
         "repo_url": "https://github.com/example/flag-repo.git",
         "repo_dir": "flag-repo",
-        "repo_base_dir": "flag-base",
+        "clones_dir": "flag-base",
         "patches_dir": "flag-patches",
         "ref": "flag-ref",
         "verbose": true,
         "dry_run": false,
         "config": "./patchy.json",
-        "absoluteRepoBaseDir": "<TEST_DIR>/flag-base",
+        "absoluteClonesDir": "<TEST_DIR>/flag-base",
         "absoluteRepoDir": "<TEST_DIR>/flag-base/flag-repo",
         "absolutePatchesDir": "<TEST_DIR>/flag-patches"
       }"
@@ -322,13 +322,13 @@ describe("createEnrichedMergedConfig", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "base",
+        clonesDir: "base",
         repoDir: "repo",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/repo.git",
-        repo_base_dir: "base",
+        clones_dir: "base",
         repo_dir: "repo",
         patches_dir: "patches",
       },
@@ -337,7 +337,7 @@ describe("createEnrichedMergedConfig", () => {
     const flags: SharedFlags = {};
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
       "patches_dir",
     ];
@@ -354,13 +354,13 @@ describe("createEnrichedMergedConfig", () => {
       "{
         "repo_url": "https://github.com/example/repo.git",
         "repo_dir": "repo",
-        "repo_base_dir": "base",
+        "clones_dir": "base",
         "patches_dir": "patches",
         "ref": "main",
         "verbose": false,
         "dry_run": false,
         "config": "./patchy.json",
-        "absoluteRepoBaseDir": "<TEST_DIR>/base",
+        "absoluteClonesDir": "<TEST_DIR>/base",
         "absoluteRepoDir": "<TEST_DIR>/base/repo",
         "absolutePatchesDir": "<TEST_DIR>/patches"
       }"
@@ -389,13 +389,13 @@ describe("createEnrichedMergedConfig", () => {
       `
       "{
         "repo_url": "https://github.com/example/repo.git",
-        "repo_base_dir": "./upstream/",
+        "clones_dir": "./clones/",
         "patches_dir": "./patches/",
         "ref": "main",
         "verbose": false,
         "dry_run": false,
         "config": "<TEST_DIR>/empty.json",
-        "absoluteRepoBaseDir": "<TEST_DIR>/upstream",
+        "absoluteClonesDir": "<TEST_DIR>/clones",
         "absolutePatchesDir": "<TEST_DIR>/patches"
       }"
     `,
@@ -439,7 +439,7 @@ describe("createEnrichedMergedConfig", () => {
     });
 
     const flags: SharedFlags = {};
-    const requiredFields: JsonConfigKey[] = ["repo_base_dir", "patches_dir"];
+    const requiredFields: JsonConfigKey[] = ["clones_dir", "patches_dir"];
 
     const result = createEnrichedMergedConfig({
       flags,
@@ -447,12 +447,12 @@ describe("createEnrichedMergedConfig", () => {
       cwd: tmpDir,
     });
 
-    // Now repo_base_dir and patches_dir have defaults, so validation fails on missing directories
+    // Now clones_dir and patches_dir have defaults, so validation fails on missing directories
     expectFailedMerge(result);
     expect(stabilizeTempDir(result.error)).toMatchInlineSnapshot(`
       "Validation errors:
 
-      Repository base directory does not exist: <TEST_DIR>/upstream
+      Clones directory does not exist: <TEST_DIR>/clones
       Patches directory does not exist: <TEST_DIR>/patches
 
       "
@@ -463,12 +463,12 @@ describe("createEnrichedMergedConfig", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "base",
+        clonesDir: "base",
         repoDir: "repo",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/repo.git",
-        repo_base_dir: "base",
+        clones_dir: "base",
         repo_dir: "repo",
         verbose: false,
       },
@@ -480,7 +480,7 @@ describe("createEnrichedMergedConfig", () => {
     };
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
     ];
 
@@ -496,13 +496,13 @@ describe("createEnrichedMergedConfig", () => {
       "{
         "repo_url": "https://github.com/example/repo.git",
         "repo_dir": "repo",
-        "repo_base_dir": "base",
+        "clones_dir": "base",
         "patches_dir": "./patches/",
         "ref": "main",
         "verbose": true,
         "dry_run": true,
         "config": "./patchy.json",
-        "absoluteRepoBaseDir": "<TEST_DIR>/base",
+        "absoluteClonesDir": "<TEST_DIR>/base",
         "absoluteRepoDir": "<TEST_DIR>/base/repo",
         "absolutePatchesDir": "<TEST_DIR>/patches"
       }"
@@ -510,16 +510,16 @@ describe("createEnrichedMergedConfig", () => {
     );
   });
 
-  it("should correctly join repo_base_dir and repo_dir paths", async () => {
+  it("should correctly join clones_dir and repo_dir paths", async () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "my-base/nested",
+        clonesDir: "my-base/nested",
         repoDir: "my-repo/nested-repo",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/repo.git",
-        repo_base_dir: "my-base/nested",
+        clones_dir: "my-base/nested",
         repo_dir: "my-repo/nested-repo",
       },
     });
@@ -527,7 +527,7 @@ describe("createEnrichedMergedConfig", () => {
     const flags: SharedFlags = {};
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
     ];
 
@@ -543,13 +543,13 @@ describe("createEnrichedMergedConfig", () => {
       "{
         "repo_url": "https://github.com/example/repo.git",
         "repo_dir": "my-repo/nested-repo",
-        "repo_base_dir": "my-base/nested",
+        "clones_dir": "my-base/nested",
         "patches_dir": "./patches/",
         "ref": "main",
         "verbose": false,
         "dry_run": false,
         "config": "./patchy.json",
-        "absoluteRepoBaseDir": "<TEST_DIR>/my-base/nested",
+        "absoluteClonesDir": "<TEST_DIR>/my-base/nested",
         "absoluteRepoDir": "<TEST_DIR>/my-base/nested/my-repo/nested-repo",
         "absolutePatchesDir": "<TEST_DIR>/patches"
       }"
@@ -564,12 +564,12 @@ describe("createEnrichedMergedConfig", () => {
       tmpDir,
       configPath: customConfigPath,
       createDirectories: {
-        repoBaseDir: "base",
+        clonesDir: "base",
         repoDir: "repo",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/custom.git",
-        repo_base_dir: "base",
+        clones_dir: "base",
         repo_dir: "repo",
         ref: "custom-branch",
       },
@@ -580,7 +580,7 @@ describe("createEnrichedMergedConfig", () => {
     };
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
     ];
 
@@ -596,13 +596,13 @@ describe("createEnrichedMergedConfig", () => {
       "{
         "repo_url": "https://github.com/example/custom.git",
         "repo_dir": "repo",
-        "repo_base_dir": "base",
+        "clones_dir": "base",
         "patches_dir": "./patches/",
         "ref": "custom-branch",
         "verbose": false,
         "dry_run": false,
         "config": "<TEST_DIR>/custom/config.json",
-        "absoluteRepoBaseDir": "<TEST_DIR>/base",
+        "absoluteClonesDir": "<TEST_DIR>/base",
         "absoluteRepoDir": "<TEST_DIR>/base/repo",
         "absolutePatchesDir": "<TEST_DIR>/patches"
       }"
@@ -615,12 +615,12 @@ describe("createEnrichedMergedConfig", () => {
     await setupTestWithConfig({
       tmpDir: subDir,
       createDirectories: {
-        repoBaseDir: "base",
+        clonesDir: "base",
         repoDir: "repo",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/repo.git",
-        repo_base_dir: "base",
+        clones_dir: "base",
         repo_dir: "repo",
       },
     });
@@ -628,7 +628,7 @@ describe("createEnrichedMergedConfig", () => {
     const flags: SharedFlags = {};
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
     ];
 
@@ -646,13 +646,13 @@ describe("createEnrichedMergedConfig", () => {
       "{
         "repo_url": "https://github.com/example/repo.git",
         "repo_dir": "repo",
-        "repo_base_dir": "base",
+        "clones_dir": "base",
         "patches_dir": "./patches/",
         "ref": "main",
         "verbose": false,
         "dry_run": false,
         "config": "./patchy.json",
-        "absoluteRepoBaseDir": "<TEST_DIR>/subdir/base",
+        "absoluteClonesDir": "<TEST_DIR>/subdir/base",
         "absoluteRepoDir": "<TEST_DIR>/subdir/base/repo",
         "absolutePatchesDir": "<TEST_DIR>/subdir/patches"
       }"
@@ -664,12 +664,12 @@ describe("createEnrichedMergedConfig", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "base",
+        clonesDir: "base",
         repoDir: "repo",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/repo.git",
-        repo_base_dir: "base",
+        clones_dir: "base",
         repo_dir: "repo",
       },
     });
@@ -677,7 +677,7 @@ describe("createEnrichedMergedConfig", () => {
     const flags: SharedFlags = {};
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
     ];
     const originalCwd = process.cwd();
@@ -695,13 +695,13 @@ describe("createEnrichedMergedConfig", () => {
       "{
         "repo_url": "https://github.com/example/repo.git",
         "repo_dir": "repo",
-        "repo_base_dir": "base",
+        "clones_dir": "base",
         "patches_dir": "./patches/",
         "ref": "main",
         "verbose": false,
         "dry_run": false,
         "config": "./patchy.json",
-        "absoluteRepoBaseDir": "<TEST_DIR>/base",
+        "absoluteClonesDir": "<TEST_DIR>/base",
         "absoluteRepoDir": "<TEST_DIR>/base/repo",
         "absolutePatchesDir": "<TEST_DIR>/patches"
       }"
@@ -736,12 +736,12 @@ describe("createEnrichedMergedConfig", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "base",
+        clonesDir: "base",
         repoDir: "repo",
       },
       jsonConfig: {
         repo_url: "invalid-url-format",
-        repo_base_dir: "base",
+        clones_dir: "base",
         repo_dir: "repo",
       },
     });
@@ -749,7 +749,7 @@ describe("createEnrichedMergedConfig", () => {
     const flags: SharedFlags = {};
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
     ];
 
@@ -773,7 +773,7 @@ describe("createEnrichedMergedConfig", () => {
     await writeJsonConfig(tmpDir, "empty-strings.json", {
       repo_url: "",
       ref: "",
-      repo_base_dir: "",
+      clones_dir: "",
     });
     const jsonPath = path.join(tmpDir, "empty-strings.json");
 
@@ -793,7 +793,7 @@ describe("createEnrichedMergedConfig", () => {
     expectSuccessfulMerge(result);
     expect(result.mergedConfig.repo_url).toBe("");
     expect(result.mergedConfig.ref).toBe("");
-    expect(result.mergedConfig.repo_base_dir).toBe("");
+    expect(result.mergedConfig.clones_dir).toBe("");
   });
 
   it("should handle Zod validation error for null values", async () => {
@@ -929,7 +929,7 @@ describe("createEnrichedMergedConfig", () => {
     await writeJsonConfig(tmpDir, "mixed-errors.json", {
       repo_url: 123,
       ref: true,
-      repo_base_dir: ["base"],
+      clones_dir: ["base"],
       repo_dir: null,
       patches_dir: {},
       verbose: "false",
@@ -952,7 +952,7 @@ describe("createEnrichedMergedConfig", () => {
     expect(result.error).toMatchInlineSnapshot(`
       "repo_url: Invalid input: expected string, received number
       repo_dir: Invalid input: expected string, received null
-      repo_base_dir: Invalid input: expected string, received array
+      clones_dir: Invalid input: expected string, received array
       patches_dir: Invalid input: expected string, received object
       ref: Invalid input: expected string, received boolean
       verbose: Invalid input: expected boolean, received string
@@ -964,7 +964,7 @@ describe("createEnrichedMergedConfig", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "env-base",
+        clonesDir: "env-base",
         repoDir: "env-repo",
         patchesDir: "env-patches",
       },
@@ -974,13 +974,13 @@ describe("createEnrichedMergedConfig", () => {
     const flags: SharedFlags = {};
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
       "patches_dir",
     ];
     const env = {
       PATCHY_REPO_URL: "https://github.com/example/env-repo.git",
-      PATCHY_REPO_BASE_DIR: "env-base",
+      PATCHY_CLONES_DIR: "env-base",
       PATCHY_REPO_DIR: "env-repo",
       PATCHY_PATCHES_DIR: "env-patches",
       PATCHY_REF: "env-branch",
@@ -1001,13 +1001,13 @@ describe("createEnrichedMergedConfig", () => {
       "{
         "repo_url": "https://github.com/example/env-repo.git",
         "repo_dir": "env-repo",
-        "repo_base_dir": "env-base",
+        "clones_dir": "env-base",
         "patches_dir": "env-patches",
         "ref": "env-branch",
         "verbose": true,
         "dry_run": true,
         "config": "./patchy.json",
-        "absoluteRepoBaseDir": "<TEST_DIR>/env-base",
+        "absoluteClonesDir": "<TEST_DIR>/env-base",
         "absoluteRepoDir": "<TEST_DIR>/env-base/env-repo",
         "absolutePatchesDir": "<TEST_DIR>/env-patches"
       }"
@@ -1019,7 +1019,7 @@ describe("createEnrichedMergedConfig", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "flag-base",
+        clonesDir: "flag-base",
         repoDir: "flag-repo",
         patchesDir: "flag-patches",
       },
@@ -1028,7 +1028,7 @@ describe("createEnrichedMergedConfig", () => {
 
     const flags: SharedFlags = {
       "repo-url": "https://github.com/example/flag-repo.git",
-      "repo-base-dir": "flag-base",
+      "clones-dir": "flag-base",
       "repo-dir": "flag-repo",
       "patches-dir": "flag-patches",
       ref: "flag-ref",
@@ -1037,13 +1037,13 @@ describe("createEnrichedMergedConfig", () => {
     };
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
       "patches_dir",
     ];
     const env = {
       PATCHY_REPO_URL: "https://github.com/example/env-repo.git",
-      PATCHY_REPO_BASE_DIR: "env-base",
+      PATCHY_CLONES_DIR: "env-base",
       PATCHY_REPO_DIR: "env-repo",
       PATCHY_PATCHES_DIR: "env-patches",
       PATCHY_REF: "env-branch",
@@ -1064,13 +1064,13 @@ describe("createEnrichedMergedConfig", () => {
       "{
         "repo_url": "https://github.com/example/flag-repo.git",
         "repo_dir": "flag-repo",
-        "repo_base_dir": "flag-base",
+        "clones_dir": "flag-base",
         "patches_dir": "flag-patches",
         "ref": "flag-ref",
         "verbose": true,
         "dry_run": true,
         "config": "./patchy.json",
-        "absoluteRepoBaseDir": "<TEST_DIR>/flag-base",
+        "absoluteClonesDir": "<TEST_DIR>/flag-base",
         "absoluteRepoDir": "<TEST_DIR>/flag-base/flag-repo",
         "absolutePatchesDir": "<TEST_DIR>/flag-patches"
       }"
@@ -1082,13 +1082,13 @@ describe("createEnrichedMergedConfig", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "env-base",
+        clonesDir: "env-base",
         repoDir: "env-repo",
         patchesDir: "env-patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/json-repo.git",
-        repo_base_dir: "json-base",
+        clones_dir: "json-base",
         repo_dir: "json-repo",
         patches_dir: "json-patches",
         ref: "json-ref",
@@ -1099,13 +1099,13 @@ describe("createEnrichedMergedConfig", () => {
     const flags: SharedFlags = {};
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
       "patches_dir",
     ];
     const env = {
       PATCHY_REPO_URL: "https://github.com/example/env-repo.git",
-      PATCHY_REPO_BASE_DIR: "env-base",
+      PATCHY_CLONES_DIR: "env-base",
       PATCHY_REPO_DIR: "env-repo",
       PATCHY_PATCHES_DIR: "env-patches",
       PATCHY_REF: "env-branch",
@@ -1125,13 +1125,13 @@ describe("createEnrichedMergedConfig", () => {
       "{
         "repo_url": "https://github.com/example/env-repo.git",
         "repo_dir": "env-repo",
-        "repo_base_dir": "env-base",
+        "clones_dir": "env-base",
         "patches_dir": "env-patches",
         "ref": "env-branch",
         "verbose": true,
         "dry_run": false,
         "config": "./patchy.json",
-        "absoluteRepoBaseDir": "<TEST_DIR>/env-base",
+        "absoluteClonesDir": "<TEST_DIR>/env-base",
         "absoluteRepoDir": "<TEST_DIR>/env-base/env-repo",
         "absolutePatchesDir": "<TEST_DIR>/env-patches"
       }"
@@ -1146,12 +1146,12 @@ describe("createEnrichedMergedConfig", () => {
       tmpDir,
       configPath: customConfigPath,
       createDirectories: {
-        repoBaseDir: "base",
+        clonesDir: "base",
         repoDir: "repo",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/env-config.git",
-        repo_base_dir: "base",
+        clones_dir: "base",
         repo_dir: "repo",
         ref: "env-config-branch",
       },
@@ -1160,7 +1160,7 @@ describe("createEnrichedMergedConfig", () => {
     const flags: SharedFlags = {};
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
     ];
     const env = {
@@ -1180,13 +1180,13 @@ describe("createEnrichedMergedConfig", () => {
       "{
         "repo_url": "https://github.com/example/env-config.git",
         "repo_dir": "repo",
-        "repo_base_dir": "base",
+        "clones_dir": "base",
         "patches_dir": "./patches/",
         "ref": "env-config-branch",
         "verbose": false,
         "dry_run": false,
         "config": "<TEST_DIR>/custom-env/env-config.json",
-        "absoluteRepoBaseDir": "<TEST_DIR>/base",
+        "absoluteClonesDir": "<TEST_DIR>/base",
         "absoluteRepoDir": "<TEST_DIR>/base/repo",
         "absolutePatchesDir": "<TEST_DIR>/patches"
       }"
@@ -1220,12 +1220,12 @@ describe("createEnrichedMergedConfig", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "base",
+        clonesDir: "base",
         repoDir: "repo",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/repo.git",
-        repo_base_dir: "base",
+        clones_dir: "base",
         repo_dir: "repo",
       },
     });
@@ -1265,7 +1265,7 @@ describe("createEnrichedMergedConfig", () => {
     } of testCases) {
       const result = createEnrichedMergedConfig({
         flags: {},
-        requiredFields: ["repo_url", "repo_base_dir", "repo_dir"],
+        requiredFields: ["repo_url", "clones_dir", "repo_dir"],
         cwd: tmpDir,
         env: { PATCHY_VERBOSE, PATCHY_DRY_RUN },
       });
@@ -1280,12 +1280,12 @@ describe("createEnrichedMergedConfig", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "json-base",
+        clonesDir: "json-base",
         repoDir: "json-repo",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/json-repo.git",
-        repo_base_dir: "json-base",
+        clones_dir: "json-base",
         repo_dir: "json-repo",
         ref: "json-ref",
       },
@@ -1294,7 +1294,7 @@ describe("createEnrichedMergedConfig", () => {
     const flags: SharedFlags = {};
     const requiredFields: JsonConfigKey[] = [
       "repo_url",
-      "repo_base_dir",
+      "clones_dir",
       "repo_dir",
     ];
     const env = {

--- a/src/cli-fields/resolver.ts
+++ b/src/cli-fields/resolver.ts
@@ -31,18 +31,16 @@ const enrichConfig = (
   cwd: string,
 ): EnrichedMergedConfig => {
   const {
-    repo_base_dir: repoBaseDir,
+    clones_dir: clonesDir,
     repo_dir: repoDir,
     patches_dir: patchesDir,
   } = config;
 
   return {
     ...config,
-    absoluteRepoBaseDir: repoBaseDir ? resolve(cwd, repoBaseDir) : undefined,
+    absoluteClonesDir: clonesDir ? resolve(cwd, clonesDir) : undefined,
     absoluteRepoDir:
-      repoBaseDir && repoDir
-        ? resolve(cwd, join(repoBaseDir, repoDir))
-        : undefined,
+      clonesDir && repoDir ? resolve(cwd, join(clonesDir, repoDir)) : undefined,
     absolutePatchesDir: patchesDir ? resolve(cwd, patchesDir) : undefined,
   };
 };

--- a/src/cli-fields/validators.ts
+++ b/src/cli-fields/validators.ts
@@ -23,8 +23,8 @@ export const directoryExists: PatchyValidatorFn = (config, key) => {
 };
 
 export const repoDirExists: PatchyValidatorFn = (config, _key) => {
-  // Skip validation if parent directory doesn't exist (will be caught by repo_base_dir validator)
-  if (!config.absoluteRepoBaseDir || !existsSync(config.absoluteRepoBaseDir)) {
+  // Skip validation if parent directory doesn't exist (will be caught by clones_dir validator)
+  if (!config.absoluteClonesDir || !existsSync(config.absoluteClonesDir)) {
     return null;
   }
   return checkPathExists(config.absoluteRepoDir);

--- a/src/commands/apply/flags.ts
+++ b/src/commands/apply/flags.ts
@@ -2,7 +2,7 @@ import { FLAG_METADATA } from "~/cli-fields";
 import type { ParsedFlags } from "~/types/utils";
 
 export const applyFlags = {
-  ...FLAG_METADATA.repo_base_dir.stricliFlag,
+  ...FLAG_METADATA.clones_dir.stricliFlag,
   ...FLAG_METADATA.repo_dir.stricliFlag,
   ...FLAG_METADATA.patches_dir.stricliFlag,
   ...FLAG_METADATA.repo_url.stricliFlag,

--- a/src/commands/apply/impl.e2e.test.ts
+++ b/src/commands/apply/impl.e2e.test.ts
@@ -22,7 +22,7 @@ describe("patchy apply", () => {
       tmpDir,
       createDirectories: {
         patchesDir: "patches",
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
       },
       jsonConfig: {
@@ -32,7 +32,7 @@ describe("patchy apply", () => {
     });
 
     const result = await runCli(
-      `patchy apply --repo-dir main --repo-base-dir repos --patches-dir patches --config patchy.json --verbose --dry-run`,
+      `patchy apply --repo-dir main --clones-dir repos --patches-dir patches --config patchy.json --verbose --dry-run`,
       tmpDir,
     );
 
@@ -48,13 +48,13 @@ describe("patchy apply", () => {
       tmpDir,
       createDirectories: {
         patchesDir: "my-patches",
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "upstream",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
         repo_dir: "upstream",
-        repo_base_dir: `${tmpDir}/repos`,
+        clones_dir: `${tmpDir}/repos`,
         patches_dir: "my-patches",
         ref: "main",
       },
@@ -77,13 +77,13 @@ describe("patchy apply", () => {
       tmpDir,
       createDirectories: {
         patchesDir: "cli-patches",
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "cli-repo",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
         repo_dir: "config-repo",
-        repo_base_dir: `${tmpDir}/repos`,
+        clones_dir: `${tmpDir}/repos`,
         patches_dir: "config-patches",
         ref: "main",
       },
@@ -159,7 +159,7 @@ describe("patchy apply", () => {
       createDirectories: {},
       jsonConfig: {
         repo_url: "https://github.com/example/repo.git",
-        repo_base_dir: "non-existent-base",
+        clones_dir: "non-existent-base",
         repo_dir: "non-existent-repo",
         patches_dir: "non-existent-patches",
       },
@@ -171,7 +171,7 @@ describe("patchy apply", () => {
     expect(result.stderr).toMatchInlineSnapshot(`
       "Validation errors:
 
-      repo_base_dir: non-existent-base in ./patchy.json does not exist: <TEST_DIR>/non-existent-base
+      clones_dir: non-existent-base in ./patchy.json does not exist: <TEST_DIR>/non-existent-base
       patches_dir: non-existent-patches in ./patchy.json does not exist: <TEST_DIR>/non-existent-patches"
     `);
   });
@@ -180,13 +180,13 @@ describe("patchy apply", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "base",
+        clonesDir: "base",
         repoDir: "repo",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "invalid-url-format",
-        repo_base_dir: "base",
+        clones_dir: "base",
         repo_dir: "repo",
       },
     });
@@ -206,7 +206,7 @@ describe("patchy apply", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "base",
+        clonesDir: "base",
         repoDir: "repo",
         patchesDir: "patches",
       },
@@ -214,7 +214,7 @@ describe("patchy apply", () => {
     });
 
     const result = await runCli(
-      `patchy apply --config empty.json --repo-url https://github.com/example/repo.git --repo-base-dir base --repo-dir repo --dry-run --verbose`,
+      `patchy apply --config empty.json --repo-url https://github.com/example/repo.git --clones-dir base --repo-dir repo --dry-run --verbose`,
       tmpDir,
     );
 
@@ -229,13 +229,13 @@ describe("patchy apply", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "base",
+        clonesDir: "base",
         repoDir: "repo",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/repo.git",
-        repo_base_dir: "base",
+        clones_dir: "base",
         repo_dir: "repo",
         verbose: false,
       },
@@ -257,13 +257,13 @@ describe("patchy apply", () => {
       tmpDir,
       configPath: customConfigPath,
       createDirectories: {
-        repoBaseDir: "base",
+        clonesDir: "base",
         repoDir: "repo",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/custom.git",
-        repo_base_dir: "base",
+        clones_dir: "base",
         repo_dir: "repo",
         ref: "custom-branch",
       },
@@ -281,17 +281,17 @@ describe("patchy apply", () => {
     `);
   });
 
-  it("should correctly join repo_base_dir and repo_dir paths", async () => {
+  it("should correctly join clones_dir and repo_dir paths", async () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "my-base/nested",
+        clonesDir: "my-base/nested",
         repoDir: "my-repo/nested-repo",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/repo.git",
-        repo_base_dir: "my-base/nested",
+        clones_dir: "my-base/nested",
         repo_dir: "my-repo/nested-repo",
       },
     });
@@ -309,13 +309,13 @@ describe("patchy apply", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repoBaseDir1",
+        clonesDir: "clonesDir1",
         repoDir: "repoDir1",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/repo.git",
-        repo_base_dir: "repoBaseDir1",
+        clones_dir: "clonesDir1",
         repo_dir: "repoDir1",
       },
     });
@@ -355,13 +355,13 @@ describe("patchy apply", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "base",
+        clonesDir: "base",
         repoDir: "repo",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/repo.git",
-        repo_base_dir: "base",
+        clones_dir: "base",
         repo_dir: "repo",
         ref: "json-ref",
       },
@@ -386,13 +386,13 @@ describe("patchy apply", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "absolute-base",
+        clonesDir: "absolute-base",
         repoDir: "repo",
         patchesDir: "absolute-patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/repo.git",
-        repo_base_dir: absoluteBase,
+        clones_dir: absoluteBase,
         repo_dir: "repo",
         patches_dir: absolutePatches,
       },
@@ -443,7 +443,7 @@ describe("patchy apply", () => {
     await writeJsonConfig(tmpDir, "empty-strings.json", {
       repo_url: "",
       ref: "",
-      repo_base_dir: "",
+      clones_dir: "",
     });
 
     const result = await runCli(
@@ -560,7 +560,7 @@ describe("patchy apply", () => {
     await writeJsonConfig(tmpDir, "mixed-errors.json", {
       repo_url: 123,
       ref: true,
-      repo_base_dir: ["base"],
+      clones_dir: ["base"],
       repo_dir: null,
       patches_dir: {},
       verbose: "false",
@@ -576,7 +576,7 @@ describe("patchy apply", () => {
     expect(result.stderr).toMatchInlineSnapshot(`
       "repo_url: Invalid input: expected string, received number
       repo_dir: Invalid input: expected string, received null
-      repo_base_dir: Invalid input: expected string, received array
+      clones_dir: Invalid input: expected string, received array
       patches_dir: Invalid input: expected string, received object
       ref: Invalid input: expected string, received boolean
       verbose: Invalid input: expected boolean, received string
@@ -588,13 +588,13 @@ describe("patchy apply", () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });
@@ -624,13 +624,13 @@ describe("patchy apply", () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });
@@ -658,13 +658,13 @@ describe("patchy apply", () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });
@@ -706,13 +706,13 @@ describe("patchy apply", () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });
@@ -751,13 +751,13 @@ describe("patchy apply", () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });
@@ -787,13 +787,13 @@ describe("patchy apply", () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });
@@ -819,13 +819,13 @@ describe("patchy apply", () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });
@@ -854,13 +854,13 @@ export const component = () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });
@@ -908,13 +908,13 @@ const other = 2;
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
         patchesDir: "patches",
       },
       jsonConfig: {
         repo_url: "https://github.com/example/test-repo.git",
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });

--- a/src/commands/apply/impl.ts
+++ b/src/commands/apply/impl.ts
@@ -89,7 +89,7 @@ export default async function (
   try {
     const result = createEnrichedMergedConfig({
       flags,
-      requiredFields: ["repo_base_dir", "repo_dir", "patches_dir"],
+      requiredFields: ["clones_dir", "repo_dir", "patches_dir"],
       cwd: this.cwd,
     });
 

--- a/src/commands/generate/flags.ts
+++ b/src/commands/generate/flags.ts
@@ -2,7 +2,7 @@ import { FLAG_METADATA } from "~/cli-fields";
 import type { ParsedFlags } from "~/types/utils";
 
 export const generateFlags = {
-  ...FLAG_METADATA.repo_base_dir.stricliFlag,
+  ...FLAG_METADATA.clones_dir.stricliFlag,
   ...FLAG_METADATA.repo_dir.stricliFlag,
   ...FLAG_METADATA.patches_dir.stricliFlag,
   ...FLAG_METADATA.repo_url.stricliFlag,

--- a/src/commands/generate/impl.e2e.test.ts
+++ b/src/commands/generate/impl.e2e.test.ts
@@ -22,11 +22,11 @@ describe("patchy generate", () => {
       tmpDir,
       createDirectories: {
         patchesDir: "patches",
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "upstream",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "upstream",
         patches_dir: "patches",
       },
@@ -61,11 +61,11 @@ describe("patchy generate", () => {
       tmpDir,
       createDirectories: {
         patchesDir: "patches",
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "upstream",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "upstream",
         patches_dir: "patches",
       },
@@ -95,11 +95,11 @@ describe("patchy generate", () => {
       tmpDir,
       createDirectories: {
         patchesDir: "patches",
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "upstream",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "upstream",
         patches_dir: "patches",
       },
@@ -131,11 +131,11 @@ describe("patchy generate", () => {
       tmpDir,
       createDirectories: {
         patchesDir: "patches",
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "upstream",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "upstream",
         patches_dir: "patches",
       },
@@ -160,11 +160,11 @@ describe("patchy generate", () => {
       tmpDir,
       createDirectories: {
         patchesDir: "patches",
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "upstream",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "upstream",
         patches_dir: "patches",
       },
@@ -199,11 +199,11 @@ describe("patchy generate", () => {
       tmpDir,
       createDirectories: {
         patchesDir: "patches",
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "upstream",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "upstream",
         patches_dir: "patches",
       },
@@ -248,10 +248,10 @@ describe("patchy generate", () => {
       tmpDir,
       createDirectories: {
         patchesDir: "patches",
-        repoBaseDir: "repos",
+        clonesDir: "repos",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "non-existent-repo",
         patches_dir: "patches",
       },
@@ -271,11 +271,11 @@ describe("patchy generate", () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "upstream",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "upstream",
         patches_dir: "new-patches",
       },
@@ -301,11 +301,11 @@ describe("patchy generate", () => {
       tmpDir,
       createDirectories: {
         patchesDir: "patches",
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "upstream",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "upstream",
         patches_dir: "patches",
       },

--- a/src/commands/generate/impl.ts
+++ b/src/commands/generate/impl.ts
@@ -72,7 +72,7 @@ export default async function (
 ): Promise<void> {
   const result = createEnrichedMergedConfig({
     flags,
-    requiredFields: ["repo_base_dir", "repo_dir"],
+    requiredFields: ["clones_dir", "repo_dir"],
     cwd: this.cwd,
   });
 

--- a/src/commands/init/flags.ts
+++ b/src/commands/init/flags.ts
@@ -2,7 +2,7 @@ import { FLAG_METADATA } from "~/cli-fields";
 import type { ParsedFlags } from "~/types/utils";
 
 export const initFlags = {
-  ...FLAG_METADATA.repo_base_dir.stricliFlag,
+  ...FLAG_METADATA.clones_dir.stricliFlag,
   ...FLAG_METADATA.patches_dir.stricliFlag,
   ...FLAG_METADATA.repo_url.stricliFlag,
   ...FLAG_METADATA.ref.stricliFlag,
@@ -15,7 +15,7 @@ export const initFlags = {
   },
   gitignore: {
     kind: "boolean",
-    brief: "Add upstream directory to .gitignore",
+    brief: "Add clones directory to .gitignore",
     optional: true,
   },
 } as const;

--- a/src/commands/init/impl.e2e.test.ts
+++ b/src/commands/init/impl.e2e.test.ts
@@ -18,11 +18,11 @@ describe("patchy init", () => {
   it("should initialize patchy with all flags", async () => {
     await setupTestWithConfig({
       tmpDir,
-      createDirectories: { repoBaseDir: "upstream" },
+      createDirectories: { clonesDir: "clones" },
     });
 
     const result = await runCli(
-      `patchy init --repo-url https://github.com/example/test-repo.git --repo-base-dir upstream --patches-dir patches --ref main --config patchy.json --force`,
+      `patchy init --repo-url https://github.com/example/test-repo.git --clones-dir clones --patches-dir patches --ref main --config patchy.json --force`,
       tmpDir,
     );
 
@@ -36,7 +36,7 @@ describe("patchy init", () => {
       $schema: await getSchemaUrl(),
       repo_url: "https://github.com/example/test-repo.git",
       ref: "main",
-      repo_base_dir: "upstream",
+      clones_dir: "clones",
       patches_dir: "patches",
     });
   });
@@ -44,11 +44,11 @@ describe("patchy init", () => {
   it("should not include repo_dir in config", async () => {
     await setupTestWithConfig({
       tmpDir,
-      createDirectories: { repoBaseDir: "upstream" },
+      createDirectories: { clonesDir: "clones" },
     });
 
     const result = await runCli(
-      `patchy init --repo-url https://github.com/example/test-repo.git --repo-base-dir upstream --patches-dir patches --ref main --force`,
+      `patchy init --repo-url https://github.com/example/test-repo.git --clones-dir clones --patches-dir patches --ref main --force`,
       tmpDir,
     );
 
@@ -62,11 +62,11 @@ describe("patchy init", () => {
     it("should add to .gitignore with --gitignore flag", async () => {
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "upstream" },
+        createDirectories: { clonesDir: "clones" },
       });
 
       const result = await runCli(
-        `patchy init --repo-url https://github.com/example/repo.git --repo-base-dir upstream --patches-dir patches --ref main --gitignore --force`,
+        `patchy init --repo-url https://github.com/example/repo.git --clones-dir clones --patches-dir patches --ref main --gitignore --force`,
         tmpDir,
       );
 
@@ -74,17 +74,17 @@ describe("patchy init", () => {
       const gitignorePath = join(tmpDir, ".gitignore");
       expect(gitignorePath).toExist();
       const content = readFileSync(gitignorePath, "utf-8");
-      expect(content).toContain("upstream/");
+      expect(content).toContain("clones/");
     });
 
     it("should not modify .gitignore with --no-gitignore flag", async () => {
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "upstream" },
+        createDirectories: { clonesDir: "clones" },
       });
 
       const result = await runCli(
-        `patchy init --repo-url https://github.com/example/repo.git --repo-base-dir upstream --patches-dir patches --ref main --no-gitignore --force`,
+        `patchy init --repo-url https://github.com/example/repo.git --clones-dir clones --patches-dir patches --ref main --no-gitignore --force`,
         tmpDir,
       );
 
@@ -96,11 +96,11 @@ describe("patchy init", () => {
     it("should not modify .gitignore without flag in non-interactive mode", async () => {
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "upstream" },
+        createDirectories: { clonesDir: "clones" },
       });
 
       const result = await runCli(
-        `patchy init --repo-url https://github.com/example/repo.git --repo-base-dir upstream --patches-dir patches --ref main --force`,
+        `patchy init --repo-url https://github.com/example/repo.git --clones-dir clones --patches-dir patches --ref main --force`,
         tmpDir,
       );
 
@@ -114,11 +114,11 @@ describe("patchy init", () => {
     it("should fail with malformed repo url - missing protocol", async () => {
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "upstream" },
+        createDirectories: { clonesDir: "clones" },
       });
 
       const result = await runCli(
-        `patchy init --repo-url github.com/example/repo --repo-base-dir upstream --patches-dir patches --ref main --config patchy.json --force`,
+        `patchy init --repo-url github.com/example/repo --clones-dir clones --patches-dir patches --ref main --config patchy.json --force`,
         tmpDir,
       );
 
@@ -131,11 +131,11 @@ describe("patchy init", () => {
     it("should fail with malformed repo url - invalid domain", async () => {
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "upstream" },
+        createDirectories: { clonesDir: "clones" },
       });
 
       const result = await runCli(
-        `patchy init --repo-url https://invalid_domain/repo --repo-base-dir upstream --patches-dir patches --ref main --config patchy.json --force`,
+        `patchy init --repo-url https://invalid_domain/repo --clones-dir clones --patches-dir patches --ref main --config patchy.json --force`,
         tmpDir,
       );
 
@@ -148,11 +148,11 @@ describe("patchy init", () => {
     it("should fail with malformed repo url - incomplete path", async () => {
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "upstream" },
+        createDirectories: { clonesDir: "clones" },
       });
 
       const result = await runCli(
-        `patchy init --repo-url https://github.com/ --repo-base-dir upstream --patches-dir patches --ref main --config patchy.json --force`,
+        `patchy init --repo-url https://github.com/ --clones-dir clones --patches-dir patches --ref main --config patchy.json --force`,
         tmpDir,
       );
 
@@ -163,17 +163,17 @@ describe("patchy init", () => {
     it("should fail when config file exists without force flag", async () => {
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "upstream" },
+        createDirectories: { clonesDir: "clones" },
         jsonConfig: { hello: "world" },
       });
 
       await runCli(
-        `patchy init --repo-url https://github.com/example/repo.git --repo-base-dir upstream --patches-dir patches --ref main --config patchy.json --force`,
+        `patchy init --repo-url https://github.com/example/repo.git --clones-dir clones --patches-dir patches --ref main --config patchy.json --force`,
         tmpDir,
       );
 
       const result = await runCli(
-        `patchy init --repo-url https://github.com/example/another-repo.git --repo-base-dir upstream --patches-dir patches --ref main --config patchy.json`,
+        `patchy init --repo-url https://github.com/example/another-repo.git --clones-dir clones --patches-dir patches --ref main --config patchy.json`,
         tmpDir,
       );
 
@@ -189,11 +189,11 @@ describe("patchy init", () => {
     it("should fail with validation error for empty repo_url", async () => {
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "upstream" },
+        createDirectories: { clonesDir: "clones" },
       });
 
       const result = await runCli(
-        `patchy init --repo-url "" --repo-base-dir upstream --patches-dir patches --ref main --config patchy.json --force`,
+        `patchy init --repo-url "" --clones-dir clones --patches-dir patches --ref main --config patchy.json --force`,
         tmpDir,
       );
 

--- a/src/commands/repo/checkout/flags.ts
+++ b/src/commands/repo/checkout/flags.ts
@@ -3,7 +3,7 @@ import type { ParsedFlags } from "~/types/utils";
 
 export const checkoutFlags = {
   ...FLAG_METADATA.repo_dir.stricliFlag,
-  ...FLAG_METADATA.repo_base_dir.stricliFlag,
+  ...FLAG_METADATA.clones_dir.stricliFlag,
   ...FLAG_METADATA.config.stricliFlag,
   ...FLAG_METADATA.verbose.stricliFlag,
   ...FLAG_METADATA.dry_run.stricliFlag,

--- a/src/commands/repo/checkout/impl.e2e.test.ts
+++ b/src/commands/repo/checkout/impl.e2e.test.ts
@@ -27,11 +27,11 @@ describe("patchy repo checkout", () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });
@@ -54,11 +54,11 @@ describe("patchy repo checkout", () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });
@@ -78,11 +78,11 @@ describe("patchy repo checkout", () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });
@@ -106,11 +106,11 @@ describe("patchy repo checkout", () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });
@@ -133,11 +133,11 @@ describe("patchy repo checkout", () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });
@@ -161,11 +161,11 @@ describe("patchy repo checkout", () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "main",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "main",
       },
     });
@@ -188,11 +188,11 @@ describe("patchy repo checkout", () => {
     await setupTestWithConfig({
       tmpDir,
       createDirectories: {
-        repoBaseDir: "repos",
+        clonesDir: "repos",
         repoDir: "custom-repo",
       },
       jsonConfig: {
-        repo_base_dir: "repos",
+        clones_dir: "repos",
         repo_dir: "default-repo",
       },
     });
@@ -234,11 +234,11 @@ describe("patchy repo checkout", () => {
       const ctx = await setupTestWithConfig({
         tmpDir,
         createDirectories: {
-          repoBaseDir: "repos",
+          clonesDir: "repos",
           repoDir: "main",
         },
         jsonConfig: {
-          repo_base_dir: "repos",
+          clones_dir: "repos",
           repo_dir: "main",
         },
       });
@@ -264,11 +264,11 @@ describe("patchy repo checkout", () => {
       const ctx = await setupTestWithConfig({
         tmpDir,
         createDirectories: {
-          repoBaseDir: "repos",
+          clonesDir: "repos",
           repoDir: "main",
         },
         jsonConfig: {
-          repo_base_dir: "repos",
+          clones_dir: "repos",
           repo_dir: "main",
         },
       });

--- a/src/commands/repo/checkout/impl.ts
+++ b/src/commands/repo/checkout/impl.ts
@@ -31,7 +31,7 @@ export default async function (
 ): Promise<void> {
   const result = createEnrichedMergedConfig({
     flags,
-    requiredFields: ["repo_base_dir", "repo_dir"],
+    requiredFields: ["clones_dir", "repo_dir"],
     cwd: this.cwd,
   });
 

--- a/src/commands/repo/clone/flags.ts
+++ b/src/commands/repo/clone/flags.ts
@@ -3,7 +3,7 @@ import type { ParsedFlags } from "~/types/utils";
 
 export const cloneFlags = {
   ...FLAG_METADATA.repo_url.stricliFlag,
-  ...FLAG_METADATA.repo_base_dir.stricliFlag,
+  ...FLAG_METADATA.clones_dir.stricliFlag,
   ...FLAG_METADATA.ref.stricliFlag,
   ...FLAG_METADATA.config.stricliFlag,
   ...FLAG_METADATA.verbose.stricliFlag,

--- a/src/commands/repo/clone/impl.e2e.test.ts
+++ b/src/commands/repo/clone/impl.e2e.test.ts
@@ -28,8 +28,8 @@ describe("patchy repo clone", () => {
 
     await setupTestWithConfig({
       tmpDir,
-      createDirectories: { repoBaseDir: "repos" },
-      jsonConfig: { repo_base_dir: "repos" },
+      createDirectories: { clonesDir: "repos" },
+      jsonConfig: { clones_dir: "repos" },
     });
 
     const result = await runCli(
@@ -52,8 +52,8 @@ describe("patchy repo clone", () => {
 
     await setupTestWithConfig({
       tmpDir,
-      createDirectories: { repoBaseDir: "repos" },
-      jsonConfig: { repo_base_dir: "repos" },
+      createDirectories: { clonesDir: "repos" },
+      jsonConfig: { clones_dir: "repos" },
     });
 
     const result = await runCli(
@@ -77,8 +77,8 @@ describe("patchy repo clone", () => {
 
     await setupTestWithConfig({
       tmpDir,
-      createDirectories: { repoBaseDir: "repos" },
-      jsonConfig: { repo_base_dir: "repos" },
+      createDirectories: { clonesDir: "repos" },
+      jsonConfig: { clones_dir: "repos" },
     });
 
     const result = await runCli(
@@ -88,7 +88,7 @@ describe("patchy repo clone", () => {
 
     expect(result).toSucceed();
     expect(result).toHaveOutput("Repository URL:");
-    expect(result).toHaveOutput("Repository base directory:");
+    expect(result).toHaveOutput("Clones directory:");
     expect(result).toHaveOutput("Target directory:");
   });
 
@@ -101,8 +101,8 @@ describe("patchy repo clone", () => {
 
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "repos" },
-        jsonConfig: { repo_base_dir: "repos" },
+        createDirectories: { clonesDir: "repos" },
+        jsonConfig: { clones_dir: "repos" },
       });
 
       const result = await runCli(
@@ -123,8 +123,8 @@ describe("patchy repo clone", () => {
 
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "repos" },
-        jsonConfig: { repo_base_dir: "repos" },
+        createDirectories: { clonesDir: "repos" },
+        jsonConfig: { clones_dir: "repos" },
       });
 
       const result = await runCli(
@@ -141,8 +141,8 @@ describe("patchy repo clone", () => {
     it("should fail with invalid git URL", async () => {
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "repos" },
-        jsonConfig: { repo_base_dir: "repos" },
+        createDirectories: { clonesDir: "repos" },
+        jsonConfig: { clones_dir: "repos" },
       });
 
       const result = await runCli(
@@ -153,7 +153,7 @@ describe("patchy repo clone", () => {
       expect(result).toFailWith("is invalid");
     });
 
-    it("should use default repo_base_dir when not specified", async () => {
+    it("should use default clones_dir when not specified", async () => {
       await writeTestFile(tmpDir, "patchy.json", "{}");
 
       const result = await runCli(
@@ -161,7 +161,7 @@ describe("patchy repo clone", () => {
         tmpDir,
       );
 
-      // Uses default ./upstream/ dir, but clone still fails because it's a non-existent repo
+      // Uses default ./clones/ dir, but clone still fails because it's a non-existent repo
       expect(result).toFailWith("Failed to clone repository");
     });
 
@@ -173,8 +173,8 @@ describe("patchy repo clone", () => {
 
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "repos" },
-        jsonConfig: { repo_base_dir: "repos" },
+        createDirectories: { clonesDir: "repos" },
+        jsonConfig: { clones_dir: "repos" },
       });
 
       mkdirSync(path.join(tmpDir, "repos", "bare-repo"), { recursive: true });
@@ -190,8 +190,8 @@ describe("patchy repo clone", () => {
     it("should fail when remote repository does not exist", async () => {
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "repos" },
-        jsonConfig: { repo_base_dir: "repos" },
+        createDirectories: { clonesDir: "repos" },
+        jsonConfig: { clones_dir: "repos" },
       });
 
       const result = await runCli(
@@ -210,8 +210,8 @@ describe("patchy repo clone", () => {
 
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "repos" },
-        jsonConfig: { repo_base_dir: "repos" },
+        createDirectories: { clonesDir: "repos" },
+        jsonConfig: { clones_dir: "repos" },
       });
 
       const result = await runCli(

--- a/src/commands/repo/clone/impl.ts
+++ b/src/commands/repo/clone/impl.ts
@@ -31,17 +31,17 @@ export default async function (
   const dryRun = config.dry_run;
   const verbose = config.verbose;
 
-  if (!config.repo_base_dir) {
+  if (!config.clones_dir) {
     this.process.stderr.write(
       chalk.red(
-        `Missing required parameter: repo_base_dir\nSet --repo-base-dir flag, ${FLAG_METADATA.repo_base_dir.env} env var, or repo_base_dir in config file.\n`,
+        `Missing required parameter: clones_dir\nSet --clones-dir flag, ${FLAG_METADATA.clones_dir.env} env var, or clones_dir in config file.\n`,
       ),
     );
     this.process.exit(1);
     return;
   }
 
-  const repoBaseDir = resolve(this.cwd, config.repo_base_dir);
+  const clonesDir = resolve(this.cwd, config.clones_dir);
 
   if (!isValidGitUrl(repoUrl)) {
     this.process.stderr.write(
@@ -62,11 +62,11 @@ export default async function (
     return;
   }
 
-  const targetDir = join(repoBaseDir, repoName);
+  const targetDir = join(clonesDir, repoName);
 
   if (verbose) {
     this.process.stdout.write(`Repository URL: ${repoUrl}\n`);
-    this.process.stdout.write(`Repository base directory: ${repoBaseDir}\n`);
+    this.process.stdout.write(`Clones directory: ${clonesDir}\n`);
     this.process.stdout.write(`Target directory: ${targetDir}\n`);
     this.process.stdout.write(`Git ref: ${ref}\n`);
   }
@@ -89,11 +89,11 @@ export default async function (
     return;
   }
 
-  ensureDirExists(repoBaseDir);
+  ensureDirExists(clonesDir);
 
   this.process.stdout.write(`Cloning ${repoUrl} to ${targetDir}...\n`);
 
-  const git = createGitClient(repoBaseDir);
+  const git = createGitClient(clonesDir);
   try {
     await git.clone(repoUrl, repoName);
   } catch (error) {

--- a/src/commands/repo/reset/flags.ts
+++ b/src/commands/repo/reset/flags.ts
@@ -3,7 +3,7 @@ import { FLAG_METADATA } from "~/cli-fields";
 import type { ParsedFlags } from "~/types/utils";
 
 export const resetFlags = {
-  ...FLAG_METADATA.repo_base_dir.stricliFlag,
+  ...FLAG_METADATA.clones_dir.stricliFlag,
   ...FLAG_METADATA.repo_dir.stricliFlag,
   ...FLAG_METADATA.config.stricliFlag,
   ...FLAG_METADATA.verbose.stricliFlag,

--- a/src/commands/repo/reset/impl.e2e.test.ts
+++ b/src/commands/repo/reset/impl.e2e.test.ts
@@ -19,7 +19,7 @@ describe("patchy repo reset", () => {
   it("should reset repository and discard local changes", async () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
-      createDirectories: { repoBaseDir: "repos", repoDir: "test-repo" },
+      createDirectories: { clonesDir: "repos", repoDir: "test-repo" },
     });
 
     const repoPath = assertDefined(ctx.absoluteRepoDir, "absoluteRepoDir");
@@ -30,7 +30,7 @@ describe("patchy repo reset", () => {
     expect(join(repoPath, "test.txt")).toHaveFileContent("modified content");
 
     const result = await runCli(
-      `patchy repo reset --repo-base-dir repos --repo-dir test-repo --yes`,
+      `patchy repo reset --clones-dir repos --repo-dir test-repo --yes`,
       tmpDir,
     );
     expect(result).toSucceed();
@@ -41,7 +41,7 @@ describe("patchy repo reset", () => {
   it("should show success message after reset", async () => {
     const ctx = await setupTestWithConfig({
       tmpDir,
-      createDirectories: { repoBaseDir: "repos", repoDir: "test-repo" },
+      createDirectories: { clonesDir: "repos", repoDir: "test-repo" },
     });
 
     const repoPath = assertDefined(ctx.absoluteRepoDir, "absoluteRepoDir");
@@ -49,7 +49,7 @@ describe("patchy repo reset", () => {
     await commitFile(repoPath, "test.txt", "content");
 
     const result = await runCli(
-      `patchy repo reset --repo-base-dir repos --repo-dir test-repo --yes`,
+      `patchy repo reset --clones-dir repos --repo-dir test-repo --yes`,
       tmpDir,
     );
 
@@ -63,11 +63,11 @@ describe("patchy repo reset", () => {
     it("should fail when repo directory does not exist", async () => {
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "repos" },
+        createDirectories: { clonesDir: "repos" },
       });
 
       const result = await runCli(
-        `patchy repo reset --repo-base-dir repos --repo-dir nonexistent`,
+        `patchy repo reset --clones-dir repos --repo-dir nonexistent`,
         tmpDir,
       );
 
@@ -77,11 +77,11 @@ describe("patchy repo reset", () => {
     it("should fail when directory is not a git repository", async () => {
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "repos", repoDir: "not-a-repo" },
+        createDirectories: { clonesDir: "repos", repoDir: "not-a-repo" },
       });
 
       const result = await runCli(
-        `patchy repo reset --repo-base-dir repos --repo-dir not-a-repo`,
+        `patchy repo reset --clones-dir repos --repo-dir not-a-repo`,
         tmpDir,
       );
 
@@ -91,7 +91,7 @@ describe("patchy repo reset", () => {
       );
     });
 
-    it("should fail when repo-base-dir directory does not exist", async () => {
+    it("should fail when clones-dir directory does not exist", async () => {
       await setupTestWithConfig({ tmpDir });
 
       const result = await runCli(
@@ -99,18 +99,18 @@ describe("patchy repo reset", () => {
         tmpDir,
       );
 
-      // Uses default ./upstream/, which doesn't exist
+      // Uses default ./clones/, which doesn't exist
       expect(result).toFailWith("does not exist");
     });
 
     it("should fail when repo-dir is missing", async () => {
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "repos" },
+        createDirectories: { clonesDir: "repos" },
       });
 
       const result = await runCli(
-        `patchy repo reset --repo-base-dir repos`,
+        `patchy repo reset --clones-dir repos`,
         tmpDir,
       );
 
@@ -122,7 +122,7 @@ describe("patchy repo reset", () => {
     it("should not reset when --dry-run is set", async () => {
       const ctx = await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "repos", repoDir: "test-repo" },
+        createDirectories: { clonesDir: "repos", repoDir: "test-repo" },
       });
 
       const repoPath = assertDefined(ctx.absoluteRepoDir, "absoluteRepoDir");
@@ -131,7 +131,7 @@ describe("patchy repo reset", () => {
       await writeFileIn(repoPath, "test.txt", "modified content");
 
       const result = await runCli(
-        `patchy repo reset --repo-base-dir repos --repo-dir test-repo --dry-run`,
+        `patchy repo reset --clones-dir repos --repo-dir test-repo --dry-run`,
         tmpDir,
       );
 
@@ -145,11 +145,11 @@ describe("patchy repo reset", () => {
     it("should still validate repo exists in dry-run mode", async () => {
       await setupTestWithConfig({
         tmpDir,
-        createDirectories: { repoBaseDir: "repos" },
+        createDirectories: { clonesDir: "repos" },
       });
 
       const result = await runCli(
-        `patchy repo reset --repo-base-dir repos --repo-dir nonexistent --dry-run`,
+        `patchy repo reset --clones-dir repos --repo-dir nonexistent --dry-run`,
         tmpDir,
       );
 

--- a/src/commands/repo/reset/impl.ts
+++ b/src/commands/repo/reset/impl.ts
@@ -13,7 +13,7 @@ export default async function (
 ): Promise<void> {
   const result = createEnrichedMergedConfig({
     flags,
-    requiredFields: ["repo_base_dir", "repo_dir"],
+    requiredFields: ["clones_dir", "repo_dir"],
     cwd: this.cwd,
   });
 

--- a/src/testing/test-utils.test.ts
+++ b/src/testing/test-utils.test.ts
@@ -13,7 +13,7 @@ describe("test-utils", () => {
       await writeTestConfig(configPath, {
         repo_url: "https://github.com/example/repo.git",
         repo_dir: "main",
-        repo_base_dir: "/tmp/repos",
+        clones_dir: "/tmp/repos",
         patches_dir: "patches",
         ref: "main",
         verbose: true,
@@ -26,7 +26,7 @@ describe("test-utils", () => {
         "{
           "repo_url": "https://github.com/example/repo.git",
           "repo_dir": "main",
-          "repo_base_dir": "/tmp/repos",
+          "clones_dir": "/tmp/repos",
           "patches_dir": "patches",
           "ref": "main",
           "verbose": true,

--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -139,7 +139,7 @@ type TestDirContext = {
   testDir: string;
   originalCwd: string;
   absolutePatchesDir: string | undefined;
-  absoluteRepoBaseDir: string | undefined;
+  absoluteClonesDir: string | undefined;
   absoluteRepoDir: string | undefined;
 };
 
@@ -147,7 +147,7 @@ const createTestDirStructure = async (
   tmpDir: string,
   directories: {
     patchesDir?: string | undefined;
-    repoBaseDir?: string | undefined;
+    clonesDir?: string | undefined;
     repoDir?: string | undefined;
   },
 ): Promise<TestDirContext> => {
@@ -159,14 +159,14 @@ const createTestDirStructure = async (
     absolutePatchesDir = join(tmpDir, directories.patchesDir);
     await mkdir(absolutePatchesDir, { recursive: true });
   }
-  let absoluteRepoBaseDir: string | undefined;
-  if (directories.repoBaseDir) {
-    absoluteRepoBaseDir = resolve(tmpDir, directories.repoBaseDir);
-    await mkdir(absoluteRepoBaseDir, { recursive: true });
+  let absoluteClonesDir: string | undefined;
+  if (directories.clonesDir) {
+    absoluteClonesDir = resolve(tmpDir, directories.clonesDir);
+    await mkdir(absoluteClonesDir, { recursive: true });
   }
   let absoluteRepoDir: string | undefined;
-  if (directories.repoDir && absoluteRepoBaseDir) {
-    absoluteRepoDir = join(absoluteRepoBaseDir, directories.repoDir);
+  if (directories.repoDir && absoluteClonesDir) {
+    absoluteRepoDir = join(absoluteClonesDir, directories.repoDir);
     await mkdir(absoluteRepoDir, { recursive: true });
   }
 
@@ -174,7 +174,7 @@ const createTestDirStructure = async (
     testDir: tmpDir,
     originalCwd,
     absolutePatchesDir,
-    absoluteRepoBaseDir,
+    absoluteClonesDir,
     absoluteRepoDir,
   };
 };
@@ -188,7 +188,7 @@ export const setupTestWithConfig = async ({
   tmpDir: string;
   createDirectories?: {
     patchesDir?: string | undefined;
-    repoBaseDir?: string | undefined;
+    clonesDir?: string | undefined;
     repoDir?: string | undefined;
   };
   jsonConfig?: Record<string, string | boolean | number>;


### PR DESCRIPTION
Renamed the `repoBaseDir` configuration field to `clonesDir` throughout the codebase to better reflect its purpose as the directory where cloned repositories are stored.