### PR TITLE
[Patchy]: Strip ./ prefix from .gitignore entries

### DIFF
--- a/src/commands/init/impl.e2e.test.ts
+++ b/src/commands/init/impl.e2e.test.ts
@@ -78,6 +78,63 @@ describe("patchy init", () => {
       expect(content).toContain("clones/");
     });
 
+    it("should strip ./ prefix from .gitignore entry", async () => {
+      const tmpDir = generateTmpDir();
+      await setupTestWithConfig({
+        tmpDir,
+        createDirectories: { clonesDir: "clones" },
+      });
+
+      const result = await runCli(
+        `patchy init --repo-url https://github.com/example/repo.git --clones-dir ./clones --patches-dir patches --ref main --gitignore --force`,
+        tmpDir,
+      );
+
+      expect(result).toSucceed();
+      const gitignorePath = join(tmpDir, ".gitignore");
+      expect(gitignorePath).toExist();
+      const content = readFileSync(gitignorePath, "utf-8");
+      expect(content).toBe("clones/\n");
+      expect(content).not.toContain("./");
+    });
+
+    it("should strip multiple ./ prefixes from .gitignore entry", async () => {
+      const tmpDir = generateTmpDir();
+      await setupTestWithConfig({
+        tmpDir,
+        createDirectories: { clonesDir: "clones" },
+      });
+
+      const result = await runCli(
+        `patchy init --repo-url https://github.com/example/repo.git --clones-dir ././clones --patches-dir patches --ref main --gitignore --force`,
+        tmpDir,
+      );
+
+      expect(result).toSucceed();
+      const gitignorePath = join(tmpDir, ".gitignore");
+      const content = readFileSync(gitignorePath, "utf-8");
+      expect(content).toBe("clones/\n");
+      expect(content).not.toContain("./");
+    });
+
+    it("should handle ./ prefix with existing trailing slash", async () => {
+      const tmpDir = generateTmpDir();
+      await setupTestWithConfig({
+        tmpDir,
+        createDirectories: { clonesDir: "clones" },
+      });
+
+      const result = await runCli(
+        `patchy init --repo-url https://github.com/example/repo.git --clones-dir ./clones/ --patches-dir patches --ref main --gitignore --force`,
+        tmpDir,
+      );
+
+      expect(result).toSucceed();
+      const gitignorePath = join(tmpDir, ".gitignore");
+      const content = readFileSync(gitignorePath, "utf-8");
+      expect(content).toBe("clones/\n");
+    });
+
     it("should not modify .gitignore with --no-gitignore flag", async () => {
       const tmpDir = generateTmpDir();
       await setupTestWithConfig({

--- a/src/commands/init/impl.ts
+++ b/src/commands/init/impl.ts
@@ -13,7 +13,7 @@ import {
 } from "~/cli-fields";
 import type { LocalContext } from "~/context";
 import { formatPathForDisplay, isPathWithinDir, resolvePath } from "~/lib/fs";
-import { extractRepoName } from "~/lib/git";
+import { extractRepoName, normalizeGitignoreEntry } from "~/lib/git";
 import { canPrompt, createPrompts } from "~/lib/prompts";
 import { isValidGitUrl, validateGitUrl } from "~/lib/validation";
 import { getSchemaUrl } from "~/version";
@@ -277,7 +277,7 @@ const addToGitignoreFile = async (
   entry: string,
 ): Promise<void> => {
   const gitignorePath = resolve(cwd, ".gitignore");
-  const normalizedEntry = entry.endsWith("/") ? entry : `${entry}/`;
+  const normalizedEntry = normalizeGitignoreEntry(entry);
 
   if (existsSync(gitignorePath)) {
     const content = readFileSync(gitignorePath, "utf8");

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { extractRepoName } from "./git";
+import { extractRepoName, normalizeGitignoreEntry } from "./git";
 
 describe("extractRepoName", () => {
   const testCases: { url: string; expected: string | undefined }[] = [
@@ -23,6 +23,26 @@ describe("extractRepoName", () => {
   testCases.forEach(({ url, expected }) => {
     it(`extracts "${expected}" from "${url}"`, () => {
       expect(extractRepoName(url)).toBe(expected);
+    });
+  });
+});
+
+describe("normalizeGitignoreEntry", () => {
+  const testCases: { entry: string; expected: string }[] = [
+    { entry: "clones", expected: "clones/" },
+    { entry: "clones/", expected: "clones/" },
+    { entry: "./clones", expected: "clones/" },
+    { entry: "./clones/", expected: "clones/" },
+    { entry: "././clones", expected: "clones/" },
+    { entry: "././clones/", expected: "clones/" },
+    { entry: "./foo/bar", expected: "foo/bar/" },
+    { entry: "foo/bar", expected: "foo/bar/" },
+    { entry: "/absolute/path", expected: "/absolute/path/" },
+  ];
+
+  testCases.forEach(({ entry, expected }) => {
+    it(`normalizes "${entry}" to "${expected}"`, () => {
+      expect(normalizeGitignoreEntry(entry)).toBe(expected);
     });
   });
 });

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -11,6 +11,11 @@ export const createGitClient = (baseDir: string): SimpleGit =>
 export const createTestGitClient = (baseDir: string): SimpleGit =>
   simpleGit({ baseDir }).env({ ...getCleanGitEnv(), LEFTHOOK: "0" });
 
+export const normalizeGitignoreEntry = (entry: string): string => {
+  const withTrailingSlash = entry.endsWith("/") ? entry : `${entry}/`;
+  return withTrailingSlash.replace(/^(\.\/)+/, "");
+};
+
 export const extractRepoName = (url: string): string | undefined => {
   const httpsMatch = url.match(/\/([^/]+?)(\.git)?$/);
   if (httpsMatch) {


### PR DESCRIPTION
Added `normalizeGitignoreEntry` function to remove leading `./` prefixes from gitignore patterns, ensuring consistent formatting regardless of how paths are provided via CLI flags.