### PR TITLE
Fix release workflow to run post-version-bump script

### DIFF
--- a/.changeset/fix-release-version-sync.md
+++ b/.changeset/fix-release-version-sync.md
@@ -1,0 +1,5 @@
+---
+"patchy-cli": patch
+---
+
+Fix release workflow to use custom version script that syncs optionalDependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           title: "chore: release"
           commit: "chore: release"
+          version: bun run changeset-version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Configure changesets/action to use custom `changeset-version` script
- This ensures `post-version-bump.ts` runs during release to sync optionalDependencies versions

## Problem
PR #203 added a post-version-bump script to sync optionalDependencies, but the release workflow was calling `changeset version` directly instead of the custom `changeset-version` script.

## Test plan
- [ ] Merge and verify next release PR includes synced optionalDependencies versions