### PR TITLE
docs: fix hooks order in README

### DIFF
--- a/.changeset/fix-hooks-doc-order.md
+++ b/.changeset/fix-hooks-doc-order.md
@@ -1,0 +1,5 @@
+---
+"patchy-cli": patch
+---
+
+Fix hooks documentation to show pre-apply before post-apply

--- a/README.md
+++ b/README.md
@@ -221,10 +221,10 @@ Patch sets can include executable scripts that run before and after patches are 
 ```
 patches/
 └── 001-add-feature/
-    ├── patchy-post-apply  # runs after patches
+    ├── patchy-pre-apply   # runs before patches
     ├── src/file.ts.diff
     ├── src/new-file.ts
-    └── patchy-pre-apply   # runs before patches
+    └── patchy-post-apply  # runs after patches
 ```
 
 ### Hook execution


### PR DESCRIPTION
Show pre-apply before post-apply for clearer understanding of execution order.